### PR TITLE
fix: restore E2E tests functionality

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const baseURL = 'http://localhost:5173';
+
 test.describe('Flujos de Administrador', () => {
   const testEmail = `admin-test-${Date.now()}@example.com`;
   const servicioNombre = `Servicio Test ${Date.now()}`;
@@ -18,14 +20,14 @@ test.describe('Flujos de Administrador', () => {
     // NOTA: En un entorno real, usaríamos storageState para estar ya logueados.
     
     // Login como admin (usando credenciales que deberían existir o crearse)
-    await page.goto('/login');
+    await page.goto(`${baseURL}/login`);
     await page.getByLabel('Email').fill('admin@test.com'); // Asumiendo credenciales de dev
     await page.getByLabel('Contraseña').fill('admin123');
     await page.getByRole('button', { name: 'Iniciar Sesión' }).click();
 
     // Navegar a Gestión de Servicios
     await page.getByRole('link', { name: 'Servicios' }).click();
-    await expect(page).toHaveURL('/admin/servicios');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/admin/servicios`));
 
     // Crear Servicio
     await page.getByRole('button', { name: 'Nuevo Servicio' }).click();
@@ -38,9 +40,18 @@ test.describe('Flujos de Administrador', () => {
     // Verificar creación
     await expect(page.getByText(servicioNombre)).toBeVisible();
 
-    // Editar Servicio
-    const card = page.locator('.bg-white', { hasText: servicioNombre });
-    await card.locator('button').first().click(); // El botón de editar (Edit icon)
+    // Editar Servicio - usar getByRole con aria-label o el nombre visible
+    // Los botones tienen aria-label implícito o usamos el icono
+    // Vamos a buscar el card y luego el primer botón (Edit)
+    const card = page.locator('div.bg-white', { hasText: servicioNombre });
+    
+    // Usar selector más específico: el botón de editar es el primero en el div de actions
+    // Tiene variant="outline"
+    await card.getByRole('button', { name: '' }).first().click();
+    
+    // Verificar que el modal de edición se abrió (contiene "Editar Servicio")
+    await expect(page.getByRole('heading', { name: 'Editar Servicio' })).toBeVisible();
+    
     await page.getByLabel('Nombre del Servicio').fill(`${servicioNombre} Editado`);
     await page.getByRole('button', { name: 'Actualizar' }).click();
 
@@ -48,9 +59,13 @@ test.describe('Flujos de Administrador', () => {
     await expect(page.getByText(`${servicioNombre} Editado`)).toBeVisible();
 
     // Eliminar Servicio
+    // El handler del dialog debe estar ANTES del click
     page.on('dialog', dialog => dialog.accept());
-    await card.locator('button').last().click(); // El botón de eliminar (Trash icon)
     
+    // El botón de eliminar es el segundo botón en el card
+    await card.getByRole('button').last().click();
+    
+    // Esperar a que el elemento desaparezca
     await expect(page.getByText(`${servicioNombre} Editado`)).not.toBeVisible();
   });
 });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Autenticación', () => {
+  const baseURL = 'http://localhost:5173';
   const testEmail = `test-${Date.now()}@example.com`;
 
   test('debe registrar un nuevo usuario exitosamente', async ({ page }) => {
-    await page.goto('/register');
+    await page.goto(`${baseURL}/register`);
     
     await page.getByLabel('Nombre').fill('Test');
     await page.getByLabel('Apellido').fill('User');
@@ -15,7 +16,7 @@ test.describe('Autenticación', () => {
     await page.getByRole('button', { name: 'Crear Cuenta' }).click();
 
     // Después del registro exitoso, debería redirigir al Home y luego a /citas
-    await expect(page).toHaveURL('/citas');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/citas`));
     
     // Validar que el Navbar esté presente y contenga elementos de usuario
     await expect(page.locator('nav')).toBeVisible();
@@ -23,7 +24,7 @@ test.describe('Autenticación', () => {
 
     // Validar navegación a Referidos
     await page.getByRole('link', { name: 'Referidos' }).click();
-    await expect(page).toHaveURL('/referidos');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/referidos`));
     await expect(page.getByRole('heading', { name: 'Referir Amigas 🎁' })).toBeVisible();
     
     // Probar copiar enlace (mockeando clipboard si es necesario, pero validando el mensaje)
@@ -32,7 +33,7 @@ test.describe('Autenticación', () => {
   });
 
   test('debe mostrar error con credenciales inválidas en login', async ({ page }) => {
-    await page.goto('/login');
+    await page.goto(`${baseURL}/login`);
     
     await page.getByLabel('Email').fill('usuario@inexistente.com');
     await page.getByLabel('Contraseña').fill('password123');
@@ -42,10 +43,10 @@ test.describe('Autenticación', () => {
   });
 
   test('debe permitir navegar a la página de registro', async ({ page }) => {
-    await page.goto('/login');
+    await page.goto(`${baseURL}/login`);
     await page.getByRole('link', { name: 'Regístrate' }).click();
     
-    await expect(page).toHaveURL('/register');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/register`));
     await expect(page.getByRole('heading', { name: 'Crear Cuenta' })).toBeVisible();
   });
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests/e2e',
+  testDir: './',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/e2e/puntos.spec.ts
+++ b/e2e/puntos.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const baseURL = 'http://localhost:5173';
+
 test.describe('Puntos y Canje de Servicios', () => {
   const adminEmail = 'admin@test.com';
   const adminPassword = 'admin123';
@@ -8,14 +10,14 @@ test.describe('Puntos y Canje de Servicios', () => {
 
   test.beforeEach(async ({ page }) => {
     // Login como Admin
-    await page.goto('/login');
+    await page.goto(`${baseURL}/login`);
     await page.getByLabel('Email').fill(adminEmail);
     await page.getByLabel('Contraseña').fill(adminPassword);
     await page.getByRole('button', { name: 'Iniciar Sesión' }).click();
     
     // Navegar a Gestión de Servicios (como hace admin.spec.ts)
     await page.getByRole('link', { name: 'Servicios' }).click();
-    await expect(page).toHaveURL('/admin/servicios');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/admin/servicios`));
   });
 
   test('debe permitir crear una cita con servicios comprados y canjeados', async ({ page }) => {
@@ -45,7 +47,7 @@ test.describe('Puntos y Canje de Servicios', () => {
     
     // 2. Ir a Citas y crear una nueva cita
     await page.getByRole('link', { name: 'Citas' }).click();
-    await expect(page).toHaveURL('/admin/citas');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/admin/citas`));
     
     // Recargar para limpiar cualquier estado
     await page.reload();
@@ -82,7 +84,7 @@ test.describe('Puntos y Canje de Servicios', () => {
     // Recargar para asegurar que los puntos se reflejen
     await page.reload();
     await page.waitForTimeout(2000);
-    await expect(page).toHaveURL('/admin/citas');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/admin/citas`));
 
     // Ahora crear la segunda cita usando esos puntos
     await page.getByRole('button', { name: 'Nueva Cita' }).click();
@@ -136,7 +138,7 @@ test.describe('Puntos y Canje de Servicios', () => {
   test('debe validar si la clienta no tiene suficientes puntos', async ({ page }) => {
     // 1. Ir a Citas
     await page.getByRole('link', { name: 'Citas' }).click();
-    await expect(page).toHaveURL('/admin/citas');
+    await expect(page).toHaveURL(new RegExp(`${baseURL}/admin/citas`));
     
     // Ir a servicios para crear un servicio caro
     await page.getByRole('link', { name: 'Servicios' }).click();


### PR DESCRIPTION
- Move tests from tests/e2e/ to e2e/ for proper Playwright config
- Fix URL handling in tests (use absolute URLs instead of relative)
- Fix admin test selectors for edit/delete buttons
- Update playwright.config.ts testDir to find tests correctly

Note: puntos.spec.ts test failing due to business logic bug (insufficient points validation), not a test setup issue.