### PR TITLE
feat: replace cita modals with dedicated admin routes

### DIFF
--- a/backend/src/__tests__/citas.handlers.test.ts
+++ b/backend/src/__tests__/citas.handlers.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCitasHttpHandlers, type CitasDeps } from '../modules/citas.handlers';
+import type { AuthJwtPayload } from '../modules/auth-context';
+
+// ---------------------------------------------------------------------------
+// Drizzle-style mock DB factory
+// ---------------------------------------------------------------------------
+
+function createMockDb() {
+  const results: unknown[] = [];
+  let selectIdx = 0;
+
+  function next(): unknown {
+    return results[selectIdx++] ?? [];
+  }
+
+  // select().from(table).where(cond)           → thenable (also has .limit, .orderBy)
+  // select().from(table).where(cond).limit(n)  → Promise<Row[]>
+  // select().from(table).where(cond).orderBy() → Promise<Row[]>
+  // select().from(table).orderBy()             → Promise<Row[]>
+  function selectChain() {
+    const result = next();
+    // .where() returns a Promise that also has .limit() and .orderBy()
+    const whereResult = Object.assign(Promise.resolve(result), {
+      limit: () => Promise.resolve(result),
+      orderBy: () => Promise.resolve(result),
+    });
+    return {
+      from: () => ({
+        where: () => whereResult,
+        orderBy: () => Promise.resolve(result),
+      }),
+    };
+  }
+
+  // insert(table).values(data)            → Promise + .returning() → Promise<Row[]>
+  // Lazy: only consumes a result slot when .returning() is actually called.
+  function insertChain() {
+    return {
+      values: () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const thenable: any = Promise.resolve(undefined);
+        thenable.returning = () => Promise.resolve(next());
+        return thenable;
+      },
+    };
+  }
+
+  // update(table).set(data).where(cond).returning() → Promise<Row[]>
+  // Lazy: only consumes a result slot when .returning() is actually called.
+  function updateChain() {
+    return {
+      set: () => ({
+        where: () => ({
+          returning: () => Promise.resolve(next()),
+        }),
+      }),
+    };
+  }
+
+  // delete(table).where(cond) → Promise
+  function deleteChain() {
+    return { where: () => Promise.resolve(undefined) };
+  }
+
+  const db = {
+    select: vi.fn(selectChain),
+    insert: vi.fn(insertChain),
+    update: vi.fn(updateChain),
+    delete: vi.fn(deleteChain),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    transaction: vi.fn(async (fn: (tx: any) => Promise<any>) => {
+      const tx = {
+        select: vi.fn(selectChain),
+        insert: vi.fn(insertChain),
+        update: vi.fn(updateChain),
+        delete: vi.fn(deleteChain),
+      };
+      return fn(tx);
+    }),
+    __push(...items: unknown[]) {
+      results.push(...items);
+      return db;
+    },
+    __reset() {
+      results.length = 0;
+      selectIdx = 0;
+    },
+  };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ADMIN_JWT: AuthJwtPayload = { sub: 'admin-001', rol: 'admin' };
+const CLIENTA_JWT: AuthJwtPayload = { sub: 'clienta-001', rol: 'clienta' };
+
+const CITA_ROW = {
+  id: 'cita-001',
+  clienta_id: 'clienta-001',
+  servicio_ids: ['serv-001'],
+  fecha_hora: new Date('2026-05-01T10:00:00Z'),
+  puntos_ganados: 10,
+  puntos_utilizados: 0,
+  estado: 'pendiente',
+  notas: null,
+  created_at: new Date('2026-04-01T00:00:00Z'),
+};
+
+const CITA_ROW_COMPLETED = { ...CITA_ROW, id: 'cita-002', estado: 'completada' };
+const CITA_ROW_CANCELLED = { ...CITA_ROW, id: 'cita-003', estado: 'cancelada' };
+
+const ITEMS_ROWS = [
+  { cita_id: 'cita-001', servicio_id: 'serv-001', tipo: 'comprado', puntos_requeridos_snapshot: 0, puntos_otorgados_snapshot: 10 },
+];
+
+const SERVICIO_MASTER = {
+  id: 'serv-001',
+  puntos_requeridos: null,
+  puntos_otorgados: 10,
+};
+
+const SERVICIO_CANJE_MASTER = {
+  id: 'serv-002',
+  puntos_requeridos: 50,
+  puntos_otorgados: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getCita handler', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let handlers: ReturnType<typeof createCitasHttpHandlers>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    handlers = createCitasHttpHandlers({ db: db as unknown as CitasDeps['db'] });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const set: Record<string, unknown> = {};
+    const result = await handlers.getCita({
+      auth: null,
+      params: { id: 'cita-001' },
+      set,
+    });
+
+    expect(set.status).toBe(401);
+    expect(result).toEqual({ error: 'unauthorized' });
+  });
+
+  it('returns 404 for non-existent cita', async () => {
+    db.__push([]); // select from citas → empty
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.getCita({
+      auth: ADMIN_JWT,
+      params: { id: 'non-existent' },
+      set,
+    });
+
+    expect(set.status).toBe(404);
+    expect(result).toEqual({ error: 'not_found' });
+  });
+
+  it('allows admin to get any cita', async () => {
+    db.__push([CITA_ROW]);    // select from citas
+    db.__push(ITEMS_ROWS);    // select from citaServicios
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.getCita({
+      auth: ADMIN_JWT,
+      params: { id: 'cita-001' },
+      set,
+    }) as Record<string, unknown>;
+
+    expect(set.status).toBeUndefined();
+    expect(result.id).toBe('cita-001');
+    expect(result.clienta_id).toBe('clienta-001');
+    expect(result.estado).toBe('pendiente');
+  });
+
+  it('returns items from citaServicios', async () => {
+    db.__push([CITA_ROW]);    // select from citas
+    db.__push(ITEMS_ROWS);    // select from citaServicios
+
+    const result = await handlers.getCita({
+      auth: ADMIN_JWT,
+      params: { id: 'cita-001' },
+      set: {},
+    }) as Record<string, unknown>;
+
+    expect(result.items).toEqual([
+      { servicio_id: 'serv-001', tipo: 'comprado' },
+    ]);
+  });
+
+  it('returns 403 when clienta tries to access another clienta cita', async () => {
+    db.__push([{ ...CITA_ROW, clienta_id: 'other-clienta' }]); // select from citas
+    // No need to push items — we return before that
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.getCita({
+      auth: CLIENTA_JWT,
+      params: { id: 'cita-001' },
+      set,
+    });
+
+    expect(set.status).toBe(403);
+    expect(result).toEqual({ error: 'forbidden' });
+  });
+
+  it('allows clienta to get her own cita', async () => {
+    db.__push([CITA_ROW]);    // select from citas
+    db.__push(ITEMS_ROWS);    // select from citaServicios
+
+    const result = await handlers.getCita({
+      auth: CLIENTA_JWT,
+      params: { id: 'cita-001' },
+      set: {},
+    }) as Record<string, unknown>;
+
+    expect(result.id).toBe('cita-001');
+    expect(result.items).toEqual([
+      { servicio_id: 'serv-001', tipo: 'comprado' },
+    ]);
+  });
+});
+
+describe('putCita handler', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let handlers: ReturnType<typeof createCitasHttpHandlers>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    handlers = createCitasHttpHandlers({ db: db as unknown as CitasDeps['db'] });
+  });
+
+  it('returns 403 for non-admin', async () => {
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: CLIENTA_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-001' },
+      body: {
+        items: [{ servicio_id: 'serv-001', tipo: 'comprado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set,
+    });
+
+    expect(set.status).toBe(403);
+    expect(result).toEqual({ error: 'forbidden' });
+  });
+
+  it('returns 404 for non-existent cita', async () => {
+    db.__push([]); // select from citas → empty
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'non-existent' },
+      body: {
+        items: [{ servicio_id: 'serv-001', tipo: 'comprado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set,
+    });
+
+    expect(set.status).toBe(404);
+    expect(result).toEqual({ error: 'not_found' });
+  });
+
+  it('rejects update on completed cita', async () => {
+    db.__push([CITA_ROW_COMPLETED]); // select from citas → completed
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-002' },
+      body: {
+        items: [{ servicio_id: 'serv-001', tipo: 'comprado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set,
+    });
+
+    expect(set.status).toBe(403);
+    expect(result).toEqual({ error: 'final_state' });
+  });
+
+  it('rejects update on cancelled cita', async () => {
+    db.__push([CITA_ROW_CANCELLED]); // select from citas → cancelled
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-003' },
+      body: {
+        items: [{ servicio_id: 'serv-001', tipo: 'comprado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set,
+    });
+
+    expect(set.status).toBe(403);
+    expect(result).toEqual({ error: 'final_state' });
+  });
+
+  it('returns 400 when items is empty', async () => {
+    db.__push([CITA_ROW]); // select from citas → exists
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-001' },
+      body: {
+        items: [],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set,
+    });
+
+    expect(set.status).toBe(400);
+    expect(result).toEqual({ error: 'items_required' });
+  });
+
+  it('admin can update items and recalculates points', async () => {
+    // 1. select from citas → existing pendiente
+    db.__push([CITA_ROW]);
+    // 2. select from servicios → masters (one comprado + one canjeado)
+    db.__push([SERVICIO_MASTER, SERVICIO_CANJE_MASTER]);
+    // 3. transaction → tx.update returning updated row
+    const updatedRow = {
+      ...CITA_ROW,
+      servicio_ids: ['serv-001', 'serv-002'],
+      puntos_ganados: 10,   // serv-001 comprado → 10 pts
+      puntos_utilizados: 50, // serv-002 canjeado → 50 pts
+    };
+    db.__push([updatedRow]); // tx.update returning
+
+    const set: Record<string, unknown> = {};
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-001' },
+      body: {
+        items: [
+          { servicio_id: 'serv-001', tipo: 'comprado' as const },
+          { servicio_id: 'serv-002', tipo: 'canjeado' as const },
+        ],
+        fecha_hora: '2026-05-02T14:00:00Z',
+        notas: 'Actualizada',
+      },
+      set,
+    }) as Record<string, unknown>;
+
+    expect(set.status).toBeUndefined(); // no error status set
+    expect(result.id).toBe('cita-001');
+    expect(result.puntos_ganados).toBe(10);
+    expect(result.puntos_utilizados).toBe(50);
+    expect(result.items).toEqual([
+      { servicio_id: 'serv-001', tipo: 'comprado' },
+      { servicio_id: 'serv-002', tipo: 'canjeado' },
+    ]);
+    // Transaction was called (delete old items + insert new + update cita)
+    expect(db.transaction).toHaveBeenCalled();
+  });
+
+  it('recalculates points with only comprado items', async () => {
+    // 1. select from citas
+    db.__push([CITA_ROW]);
+    // 2. select from servicios
+    db.__push([SERVICIO_MASTER]);
+    // 3. tx.update returning
+    const updatedRow = {
+      ...CITA_ROW,
+      puntos_ganados: 10,
+      puntos_utilizados: 0,
+    };
+    db.__push([updatedRow]);
+
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-001' },
+      body: {
+        items: [{ servicio_id: 'serv-001', tipo: 'comprado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set: {},
+    }) as Record<string, unknown>;
+
+    expect(result.puntos_ganados).toBe(10);
+    expect(result.puntos_utilizados).toBe(0);
+  });
+
+  it('recalculates points with only canjeado items', async () => {
+    // 1. select from citas
+    db.__push([CITA_ROW]);
+    // 2. select from servicios → canjeado master
+    db.__push([SERVICIO_CANJE_MASTER]);
+    // 3. tx.update returning
+    const updatedRow = {
+      ...CITA_ROW,
+      servicio_ids: ['serv-002'],
+      puntos_ganados: 0,
+      puntos_utilizados: 50,
+    };
+    db.__push([updatedRow]);
+
+    const result = await handlers.putCita({
+      auth: ADMIN_JWT,
+      status: { code: vi.fn() },
+      params: { id: 'cita-001' },
+      body: {
+        items: [{ servicio_id: 'serv-002', tipo: 'canjeado' as const }],
+        fecha_hora: '2026-05-01T10:00:00Z',
+      },
+      set: {},
+    }) as Record<string, unknown>;
+
+    expect(result.puntos_ganados).toBe(0);
+    expect(result.puntos_utilizados).toBe(50);
+  });
+});

--- a/backend/src/domain/transformers/citas.ts
+++ b/backend/src/domain/transformers/citas.ts
@@ -1,21 +1,25 @@
-import type { PublicCita } from '../types/citas';
+import type { CitaItem, PublicCita } from '../types/citas';
 import { asIsoString } from './iso';
 
-export function toPublicCita(row: {
-  id: string;
-  clienta_id: string;
-  servicio_ids: string[];
-  fecha_hora: unknown;
-  puntos_ganados: number;
-  puntos_utilizados: number;
-  estado: unknown;
-  notas: string | null;
-  created_at: unknown;
-}): PublicCita {
+export function toPublicCita(
+  row: {
+    id: string;
+    clienta_id: string;
+    servicio_ids: string[];
+    fecha_hora: unknown;
+    puntos_ganados: number;
+    puntos_utilizados: number;
+    estado: unknown;
+    notas: string | null;
+    created_at: unknown;
+  },
+  items?: CitaItem[]
+): PublicCita {
   return {
     id: row.id,
     clienta_id: row.clienta_id,
     servicio_ids: row.servicio_ids,
+    items,
     fecha_hora: asIsoString(row.fecha_hora),
     puntos_ganados: row.puntos_ganados,
     puntos_utilizados: row.puntos_utilizados,

--- a/backend/src/domain/types/citas.ts
+++ b/backend/src/domain/types/citas.ts
@@ -1,9 +1,15 @@
 export type CitaEstado = 'pendiente' | 'confirmada' | 'completada' | 'cancelada';
 
+export type CitaItem = {
+  servicio_id: string;
+  tipo: 'comprado' | 'canjeado';
+};
+
 export type PublicCita = {
   id: string;
   clienta_id: string;
   servicio_ids: string[];
+  items?: CitaItem[];
   fecha_hora: string;
   puntos_ganados: number;
   puntos_utilizados: number;

--- a/backend/src/modules/citas.handlers.ts
+++ b/backend/src/modules/citas.handlers.ts
@@ -25,6 +25,12 @@ export type CitaPatchBody = {
   notas?: string;
 };
 
+export type CitaUpdateBody = {
+  items: CitaItemInput[];
+  fecha_hora: string;
+  notas?: string;
+};
+
 export type CitaIdParams = {
   id: string;
 };
@@ -42,10 +48,24 @@ export type CitasListCtx = {
   query: CitasListQuery;
 };
 
+export type CitaGetCtx = {
+  auth?: unknown;
+  params: CitaIdParams;
+  set: { status?: number | string };
+};
+
 export type CitaCreateCtx = {
   auth?: unknown;
   status: StatusHelper;
   body: CitaCreateBody;
+  set: { status?: number | string };
+};
+
+export type CitaUpdateCtx = {
+  auth?: unknown;
+  status: StatusHelper;
+  params: CitaIdParams;
+  body: CitaUpdateBody;
   set: { status?: number | string };
 };
 
@@ -88,10 +108,10 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
             .from(citas)
             .where(eq(citas.clienta_id, query.clienta_id))
             .orderBy(asc(citas.fecha_hora));
-          return rows.map(toPublicCita);
+          return rows.map((row) => toPublicCita(row));
         }
         const rows = await deps.db.select().from(citas).orderBy(asc(citas.fecha_hora));
-        return rows.map(toPublicCita);
+        return rows.map((row) => toPublicCita(row));
       }
 
       const clienta_id = jwt?.sub;
@@ -106,7 +126,7 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
         .from(citas)
         .where(eq(citas.clienta_id, clienta_id))
         .orderBy(asc(citas.fecha_hora));
-      return rows.map(toPublicCita);
+      return rows.map((row) => toPublicCita(row));
     },
 
     /** Lista proximas citas (solo admin). */
@@ -122,7 +142,7 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
         .from(citas)
         .where(gte(citas.fecha_hora, now))
         .orderBy(asc(citas.fecha_hora));
-      return rows.map(toPublicCita);
+      return rows.map((row) => toPublicCita(row));
     },
 
     /** Lista citas pendientes/confirmadas (solo admin). */
@@ -137,7 +157,7 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
         .from(citas)
         .where(inArray(citas.estado, ['pendiente', 'confirmada']))
         .orderBy(asc(citas.fecha_hora));
-      return rows.map(toPublicCita);
+      return rows.map((row) => toPublicCita(row));
     },
 
     /** Crea una cita. Admin puede elegir clienta_id; clienta siempre crea para si misma. */
@@ -207,6 +227,125 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
 
       set.status = 201;
       return toPublicCita(inserted);
+    },
+
+    /** Obtiene una cita por ID con sus items. */
+    getCita: async (ctx: unknown) => {
+      const { auth, params, set } = ctx as CitaGetCtx;
+      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
+      if (!jwt?.sub) {
+        set.status = 401;
+        return { error: 'unauthorized' };
+      }
+
+      const existing = await deps.db.select().from(citas).where(eq(citas.id, params.id)).limit(1);
+      const cita = existing[0];
+      if (!cita) {
+        set.status = 404;
+        return { error: 'not_found' };
+      }
+
+      if (jwt.rol !== 'admin' && cita.clienta_id !== jwt.sub) {
+        set.status = 403;
+        return { error: 'forbidden' };
+      }
+
+      const rows = await deps.db
+        .select()
+        .from(citaServicios)
+        .where(eq(citaServicios.cita_id, params.id));
+
+      const items = rows.map((r) => ({
+        servicio_id: r.servicio_id,
+        tipo: r.tipo as 'comprado' | 'canjeado',
+      }));
+
+      return toPublicCita(cita, items);
+    },
+
+    /** Actualiza una cita (items, fecha_hora, notas). Solo admin, solo si estado es pendiente/confirmada. */
+    putCita: async (ctx: unknown) => {
+      const { auth, params, body, set } = ctx as CitaUpdateCtx;
+      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
+      if (jwt?.rol !== 'admin') {
+        set.status = 403;
+        return { error: 'forbidden' };
+      }
+
+      const existing = await deps.db.select().from(citas).where(eq(citas.id, params.id)).limit(1);
+      const cita = existing[0];
+      if (!cita) {
+        set.status = 404;
+        return { error: 'not_found' };
+      }
+
+      if (cita.estado === 'completada' || cita.estado === 'cancelada') {
+        set.status = 403;
+        return { error: 'final_state' };
+      }
+
+      if (!body.items || body.items.length === 0) {
+        set.status = 400;
+        return { error: 'items_required' };
+      }
+
+      const servicioIds = body.items.map((it) => it.servicio_id);
+      const masters = await deps.db.select().from(servicios).where(inArray(servicios.id, servicioIds));
+
+      try {
+        validateCitaItems(body.items, masters);
+      } catch (e: any) {
+        set.status = 400;
+        return { error: e.message };
+      }
+
+      const { puntos_ganados, puntos_utilizados } = computeCitaTotals(body.items, masters);
+
+      const updated = await deps.db.transaction(async (tx) => {
+        // Eliminar items anteriores
+        await tx.delete(citaServicios).where(eq(citaServicios.cita_id, params.id));
+
+        // Insertar nuevos items
+        await tx.insert(citaServicios).values(
+          body.items.map((it) => {
+            const m = masters.find((s) => s.id === it.servicio_id)!;
+            return {
+              cita_id: params.id,
+              servicio_id: it.servicio_id,
+              tipo: it.tipo,
+              puntos_requeridos_snapshot: m.puntos_requeridos,
+              puntos_otorgados_snapshot: m.puntos_otorgados,
+            };
+          })
+        );
+
+        // Actualizar la cita
+        const rows = await tx
+          .update(citas)
+          .set({
+            servicio_ids: servicioIds,
+            fecha_hora: new Date(body.fecha_hora),
+            puntos_ganados,
+            puntos_utilizados,
+            notas: body.notas,
+          })
+          .where(eq(citas.id, params.id))
+          .returning();
+
+        return rows[0];
+      });
+
+      if (!updated) {
+        set.status = 500;
+        return { error: 'internal_server_error' };
+      }
+
+      const items = body.items.map((it) => ({
+        servicio_id: it.servicio_id,
+        tipo: it.tipo as 'comprado' | 'canjeado',
+      }));
+
+      return toPublicCita(updated, items);
     },
 
     /**

--- a/backend/src/modules/citas.routes.ts
+++ b/backend/src/modules/citas.routes.ts
@@ -42,6 +42,34 @@ export function registerCitasRoutes(app: AnyElysia) {
         }),
       }
     )
+    .get(
+      '/api/citas/:id',
+      handlers.getCita,
+      {
+        params: t.Object({
+          id: t.String({ format: 'uuid' }),
+        }),
+      }
+    )
+    .put(
+      '/api/citas/:id',
+      handlers.putCita,
+      {
+        params: t.Object({
+          id: t.String({ format: 'uuid' }),
+        }),
+        body: t.Object({
+          items: t.Array(
+            t.Object({
+              servicio_id: t.String({ format: 'uuid' }),
+              tipo: t.Union([t.Literal('comprado'), t.Literal('canjeado')]),
+            })
+          ),
+          fecha_hora: t.String({ format: 'date-time' }),
+          notas: t.Optional(t.String()),
+        }),
+      }
+    )
     .patch(
       '/api/citas/:id',
       handlers.patchCita,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import Premios from './pages/Premios';
 import AdminDashboard from './pages/admin/Dashboard';
 import AdminClientas from './pages/admin/Clientas';
 import AdminCitas from './pages/admin/Citas';
+import AdminNuevaCita from './pages/admin/NuevaCita';
+import AdminEditarCita from './pages/admin/EditarCita';
 import AdminServicios from './pages/admin/Servicios';
 import AdminPremios from './pages/admin/Premios';
 
@@ -98,6 +100,26 @@ function App() {
               <RequireAdmin>
                 <LayoutWithNav>
                   <AdminClientas />
+                </LayoutWithNav>
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/citas/nueva"
+            element={
+              <RequireAdmin>
+                <LayoutWithNav>
+                  <AdminNuevaCita />
+                </LayoutWithNav>
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/citas/:id/editar"
+            element={
+              <RequireAdmin>
+                <LayoutWithNav>
+                  <AdminEditarCita />
                 </LayoutWithNav>
               </RequireAdmin>
             }

--- a/frontend/src/pages/admin/CitaForm.tsx
+++ b/frontend/src/pages/admin/CitaForm.tsx
@@ -1,0 +1,323 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { profilesService } from '../../services/profiles';
+import { serviciosService } from '../../services/servicios';
+import { Button } from '../../components/Button';
+import { Input } from '../../components/Input';
+import { Select } from '../../components/Select';
+import type { Cita, Profile, Servicio } from '@fidelity-card/shared';
+
+export type CitaFormData = {
+  clienta_id: string;
+  fecha_hora: string;
+  items: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[];
+  notas: string;
+};
+
+interface CitaFormProps {
+  initialData?: Cita | null;
+  initialItems?: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[];
+  onSubmit: (data: CitaFormData) => Promise<void>;
+  submitting: boolean;
+  error: string | null;
+}
+
+function toDateTimeLocalValue(date: Date) {
+  const tzOffsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - tzOffsetMs).toISOString().slice(0, 16);
+}
+
+function getDefaultFechaHora() {
+  const base = new Date();
+  base.setMinutes(0, 0, 0);
+  base.setHours(base.getHours() + 1);
+  return toDateTimeLocalValue(base);
+}
+
+export default function CitaForm({ initialData, initialItems, onSubmit, submitting, error }: CitaFormProps) {
+  const navigate = useNavigate();
+
+  const [clientas, setClientas] = useState<Profile[]>([]);
+  const [servicios, setServicios] = useState<Servicio[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [clientaId, setClientaId] = useState(initialData?.clienta_id ?? '');
+  const [fechaHora, setFechaHora] = useState(
+    initialData?.fecha_hora ? toDateTimeLocalValue(new Date(initialData.fecha_hora)) : getDefaultFechaHora()
+  );
+  const [selectedServicios, setSelectedServicios] = useState<Map<string, 'comprado' | 'canjeado'>>(
+    initialItems
+      ? new Map(initialItems.map((it) => [it.servicio_id, it.tipo]))
+      : new Map()
+  );
+  const [notas, setNotas] = useState(initialData?.notas ?? '');
+
+  const isEditMode = !!initialData;
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [clientasData, serviciosData] = await Promise.all([
+          profilesService.getByRol('clienta'),
+          serviciosService.getAll()
+        ]);
+        setClientas(clientasData);
+        setServicios(serviciosData);
+      } catch (error) {
+        console.error('Error al cargar datos del formulario:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, []);
+
+  function getClientaById(id: string) {
+    return clientas.find((c) => c.id === id);
+  }
+
+  function toggleServicio(servicioId: string) {
+    setSelectedServicios((prev) => {
+      const next = new Map(prev);
+      if (next.has(servicioId)) {
+        next.delete(servicioId);
+      } else {
+        next.set(servicioId, 'comprado');
+      }
+      return next;
+    });
+  }
+
+  function setItemTipo(servicioId: string, tipo: 'comprado' | 'canjeado') {
+    setSelectedServicios((prev) => {
+      const next = new Map(prev);
+      next.set(servicioId, tipo);
+      return next;
+    });
+  }
+
+  const itemsArray = Array.from(selectedServicios.entries()).map(([servicio_id, tipo]) => ({
+    servicio_id,
+    tipo
+  }));
+
+  function getPuntosGanados() {
+    return itemsArray.reduce((acc, it) => {
+      if (it.tipo !== 'comprado') return acc;
+      const servicio = servicios.find((s) => s.id === it.servicio_id);
+      return acc + (servicio?.puntos_otorgados ?? 0);
+    }, 0);
+  }
+
+  function getPuntosUtilizados() {
+    return itemsArray.reduce((acc, it) => {
+      if (it.tipo !== 'canjeado') return acc;
+      const servicio = servicios.find((s) => s.id === it.servicio_id);
+      return acc + (servicio?.puntos_requeridos ?? 0);
+    }, 0);
+  }
+
+  function getPrecioTotal() {
+    return itemsArray.reduce((acc, it) => {
+      if (it.tipo !== 'comprado') return acc;
+      const servicio = servicios.find((s) => s.id === it.servicio_id);
+      return acc + (servicio?.precio ?? 0);
+    }, 0);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+
+    await onSubmit({
+      clienta_id: clientaId,
+      fecha_hora: new Date(fechaHora).toISOString(),
+      items: itemsArray,
+      notas: notas.trim() ? notas.trim() : ''
+    });
+  }
+
+  function handleCancel() {
+    navigate('/admin/citas');
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  const clienta = getClientaById(clientaId);
+  const puntosDisponibles = clienta?.puntos ?? 0;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <Select
+        id="clienta_id"
+        label="Clienta"
+        options={clientas.map((c) => ({
+          value: c.id,
+          label: `${c.nombre} ${c.apellido}`
+        }))}
+        value={clientaId}
+        onChange={(e) => setClientaId(e.target.value)}
+        required
+      />
+
+      <Input
+        id="fecha_hora"
+        type="datetime-local"
+        label="Fecha y Hora"
+        value={fechaHora}
+        onChange={(e) => setFechaHora(e.target.value)}
+        required
+      />
+
+      <div className="bg-gray-50 p-4 rounded-lg border border-gray-200">
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-sm font-medium text-gray-700">Resumen de la cita</label>
+          <div className="text-xs text-gray-500">
+            Puntos disponibles: <span className="font-semibold">{puntosDisponibles} pts</span>
+          </div>
+        </div>
+        <div className="space-y-1">
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Puntos a descontar (canjes):</span>
+            <span data-testid="puntos-descontar" className="font-bold text-red-600">-{getPuntosUtilizados()} pts</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Puntos a ganar (compras):</span>
+            <span data-testid="puntos-ganar" className="font-bold text-primary">+{getPuntosGanados()} pts</span>
+          </div>
+          <div className="flex justify-between text-sm pt-2 mt-2 border-t border-gray-200">
+            <span className="font-medium text-gray-900">Total a pagar:</span>
+            <span data-testid="precio-total" className="font-bold text-gray-900">${getPrecioTotal()}</span>
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-gray-500 italic">
+          Los puntos se actualizarán en la cuenta de la clienta al completar la cita.
+        </p>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium text-gray-700">Servicios</label>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3" id="servicios-list-container" data-testid="servicios-list">
+          {servicios.map((servicio) => {
+            const tipo = selectedServicios.get(servicio.id);
+            const checked = !!tipo;
+
+            return (
+              <div
+                key={servicio.id}
+                data-testid={`servicio-item-${servicio.nombre}`}
+                className={
+                  'flex flex-col gap-2 rounded-lg border p-3 transition-colors ' +
+                  (checked
+                    ? 'border-primary bg-primary/5'
+                    : 'border-gray-200 hover:bg-gray-50')
+                }
+              >
+                <div className="flex items-center gap-3">
+                  <input
+                    id={`check-${servicio.id}`}
+                    data-testid={`check-${servicio.nombre}`}
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleServicio(servicio.id)}
+                    className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+                  />
+                  <label
+                    htmlFor={`check-${servicio.id}`}
+                    className="flex-1 min-w-0 cursor-pointer"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="font-medium text-gray-900 truncate" data-testid="servicio-nombre">
+                        {servicio.nombre}
+                      </div>
+                      <div className="text-sm font-semibold text-gray-900 shrink-0">
+                        ${servicio.precio}
+                      </div>
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {servicio.puntos_otorgados} pts otorgados
+                      {servicio.puntos_requeridos && ` | ${servicio.puntos_requeridos} pts req`}
+                    </div>
+                  </label>
+                </div>
+
+                {checked && tipo && (
+                  <div className="flex gap-2 ml-7 mt-1">
+                    <button
+                      type="button"
+                      data-testid="btn-comprado"
+                      onClick={() => setItemTipo(servicio.id, 'comprado')}
+                      className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                        tipo === 'comprado'
+                          ? 'bg-primary text-white border-primary'
+                          : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
+                      }`}
+                    >
+                      Compra
+                    </button>
+                    {servicio.puntos_requeridos ? (
+                      <button
+                        type="button"
+                        data-testid="btn-canjeado"
+                        onClick={() => setItemTipo(servicio.id, 'canjeado')}
+                        disabled={!clientaId || puntosDisponibles < (servicio.puntos_requeridos ?? 0)}
+                        className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                          tipo === 'canjeado'
+                            ? 'bg-accent text-white border-accent'
+                            : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed'
+                        }`}
+                        title={!clientaId ? 'Selecciona una clienta primero' : puntosDisponibles < (servicio.puntos_requeridos ?? 0) ? 'Puntos insuficientes' : ''}
+                      >
+                        Canje
+                      </button>
+                    ) : (
+                      <span data-testid="no-canjeable" className="text-[10px] text-gray-400 self-center">No canjeable</span>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {servicios.length === 0 && (
+          <div className="text-sm text-gray-500">No hay servicios cargados.</div>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Notas (opcional)</label>
+        <textarea
+          id="notas"
+          rows={3}
+          value={notas}
+          onChange={(e) => setNotas(e.target.value)}
+          placeholder="Ej: traer diseño de referencia..."
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+        />
+      </div>
+
+      <div className="flex justify-end gap-3">
+        <Button type="button" variant="outline" onClick={handleCancel} disabled={submitting}>
+          Cancelar
+        </Button>
+        <Button type="submit" loading={submitting}>
+          {isEditMode ? 'Guardar Cambios' : 'Crear Cita'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/admin/Citas.tsx
+++ b/frontend/src/pages/admin/Citas.tsx
@@ -130,11 +130,12 @@ export default function AdminCitas() {
               Administra todas las citas del salón
             </p>
           </div>
-          <Link to="/admin/citas/nueva">
-            <Button>
-              <Plus size={18} className="mr-2" />
-              Nueva Cita
-            </Button>
+          <Link
+            to="/admin/citas/nueva"
+            className="inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 bg-primary hover:bg-primary-light text-white shadow-md hover:shadow-lg px-4 py-2 text-base"
+          >
+            <Plus size={18} className="mr-2" />
+            Nueva Cita
           </Link>
         </div>
 
@@ -265,14 +266,12 @@ export default function AdminCitas() {
                               </div>
                             )}
 
-                            <Link to={`/admin/citas/${cita.id}/editar`}>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                              >
-                                <Pencil size={16} className="mr-2" />
-                                Editar
-                              </Button>
+                            <Link
+                              to={`/admin/citas/${cita.id}/editar`}
+                              className="inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 border-2 border-primary text-primary hover:bg-primary hover:text-white px-3 py-1.5 text-sm"
+                            >
+                              <Pencil size={16} className="mr-2" />
+                              Editar
                             </Link>
 
                             {(cita.estado === 'pendiente' || cita.estado === 'confirmada') && (

--- a/frontend/src/pages/admin/Citas.tsx
+++ b/frontend/src/pages/admin/Citas.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { citasService } from '../../services/citas';
 import { profilesService } from '../../services/profiles';
-import { serviciosService } from '../../services/servicios';
-import type { Cita, Profile, Servicio } from '@fidelity-card/shared';
+import type { Cita, Profile } from '@fidelity-card/shared';
 import { Card, CardContent } from '../../components/Card';
 import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 import { Select } from '../../components/Select';
 import { ApiError } from '../../services/api';
-import { Calendar, Clock, User, Plus, Filter, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
+import { Calendar, Clock, User, Plus, Filter, CheckCircle, XCircle, AlertCircle, Pencil } from 'lucide-react';
 import { formatearFecha, formatearHora, getEstadoCitaColor, esFechaPasada } from '../../utils';
 
 type CitaEstado = Cita['estado'];
@@ -16,7 +16,6 @@ type CitaEstado = Cita['estado'];
 export default function AdminCitas() {
   const [citas, setCitas] = useState<Cita[]>([]);
   const [clientas, setClientas] = useState<Profile[]>([]);
-  const [servicios, setServicios] = useState<Servicio[]>([]);
   const [filteredCitas, setFilteredCitas] = useState<Cita[]>([]);
   const [loading, setLoading] = useState(true);
   const [filtro, setFiltro] = useState<{ estado: CitaEstado | ''; fecha: string }>({ estado: '', fecha: '' });
@@ -24,33 +23,16 @@ export default function AdminCitas() {
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
 
-  const [modalOpen, setModalOpen] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [modalError, setModalError] = useState<string | null>(null);
-  const [formData, setFormData] = useState<{
-    clienta_id: string;
-    fecha_hora: string;
-    items: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[];
-    notas: string;
-  }>({
-    clienta_id: '',
-    fecha_hora: '',
-    items: [],
-    notas: ''
-  });
-
   useEffect(() => {
     async function loadData() {
       try {
-        const [citasData, clientasData, serviciosData] = await Promise.all([
+        const [citasData, clientasData] = await Promise.all([
           citasService.getAll(),
-          profilesService.getByRol('clienta'),
-          serviciosService.getAll()
+          profilesService.getByRol('clienta')
         ]);
         setCitas(citasData);
         setFilteredCitas(citasData);
         setClientas(clientasData);
-        setServicios(serviciosData);
       } catch (error) {
         console.error('Error al cargar datos:', error);
       } finally {
@@ -68,7 +50,7 @@ export default function AdminCitas() {
     }
 
     if (filtro.fecha) {
-      filtered = filtered.filter(cita => 
+      filtered = filtered.filter(cita =>
         cita.fecha_hora.startsWith(filtro.fecha)
       );
     }
@@ -91,124 +73,6 @@ export default function AdminCitas() {
 
   function limpiarFiltros() {
     setFiltro({ estado: '', fecha: '' });
-  }
-
-  function toDateTimeLocalValue(date: Date) {
-    const tzOffsetMs = date.getTimezoneOffset() * 60_000;
-    return new Date(date.getTime() - tzOffsetMs).toISOString().slice(0, 16);
-  }
-
-  function openModal() {
-    const base = new Date();
-    base.setMinutes(0, 0, 0);
-    base.setHours(base.getHours() + 1);
-
-    setModalError(null);
-    setFormData({
-      clienta_id: '',
-      fecha_hora: toDateTimeLocalValue(base),
-      items: [],
-      notas: ''
-    });
-    setModalOpen(true);
-  }
-
-  function closeModal() {
-    setModalOpen(false);
-    setSubmitting(false);
-    setModalError(null);
-  }
-
-  function toggleServicio(servicioId: string) {
-    setFormData((prev) => {
-      const exists = prev.items.find((it) => it.servicio_id === servicioId);
-      return {
-        ...prev,
-        items: exists
-          ? prev.items.filter((it) => it.servicio_id !== servicioId)
-          : [...prev.items, { servicio_id: servicioId, tipo: 'comprado' }]
-      };
-    });
-  }
-
-  function setItemTipo(servicioId: string, tipo: 'comprado' | 'canjeado') {
-    setFormData((prev) => ({
-      ...prev,
-      items: prev.items.map((it) => (it.servicio_id === servicioId ? { ...it, tipo } : it))
-    }));
-  }
-
-  function getPuntosGanados(items: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[]) {
-    return items.reduce((acc, it) => {
-      if (it.tipo !== 'comprado') return acc;
-      const servicio = servicios.find((s) => s.id === it.servicio_id);
-      return acc + (servicio?.puntos_otorgados ?? 0);
-    }, 0);
-  }
-
-  function getPuntosUtilizados(items: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[]) {
-    return items.reduce((acc, it) => {
-      if (it.tipo !== 'canjeado') return acc;
-      const servicio = servicios.find((s) => s.id === it.servicio_id);
-      return acc + (servicio?.puntos_requeridos ?? 0);
-    }, 0);
-  }
-
-  function getPrecioTotal(items: { servicio_id: string; tipo: 'comprado' | 'canjeado' }[]) {
-    return items.reduce((acc, it) => {
-      if (it.tipo !== 'comprado') return acc;
-      const servicio = servicios.find((s) => s.id === it.servicio_id);
-      return acc + (servicio?.precio ?? 0);
-    }, 0);
-  }
-
-  async function handleCreateCita(e: React.FormEvent) {
-    e.preventDefault();
-    if (submitting) return;
-
-    setSubmitting(true);
-    setModalError(null);
-
-    try {
-      if (!formData.clienta_id) {
-        setModalError('Selecciona una clienta.');
-        return;
-      }
-      if (formData.items.length === 0) {
-        setModalError('Selecciona al menos un servicio.');
-        return;
-      }
-      if (!formData.fecha_hora) {
-        setModalError('Selecciona fecha y hora.');
-        return;
-      }
-
-      const clienta = getClientaById(formData.clienta_id);
-      const puntos_utilizados = getPuntosUtilizados(formData.items);
-
-      if (puntos_utilizados > (clienta?.puntos ?? 0)) {
-        setModalError('La clienta no tiene suficientes puntos para este canje.');
-        return;
-      }
-
-      const payload = {
-        clienta_id: formData.clienta_id,
-        items: formData.items,
-        fecha_hora: new Date(formData.fecha_hora).toISOString(),
-        notas: formData.notas.trim() ? formData.notas.trim() : undefined
-      };
-
-      await citasService.create(payload);
-
-      const citasData = await citasService.getAll();
-      setCitas(citasData);
-      closeModal();
-    } catch (error) {
-      console.error('Error al crear cita:', error);
-      setModalError('No se pudo crear la cita. Intenta nuevamente.');
-    } finally {
-      setSubmitting(false);
-    }
   }
 
   function resolvePatchErrorMessage(error: unknown) {
@@ -266,10 +130,12 @@ export default function AdminCitas() {
               Administra todas las citas del salón
             </p>
           </div>
-          <Button onClick={openModal}>
-            <Plus size={18} className="mr-2" />
-            Nueva Cita
-          </Button>
+          <Link to="/admin/citas/nueva">
+            <Button>
+              <Plus size={18} className="mr-2" />
+              Nueva Cita
+            </Button>
+          </Link>
         </div>
 
         {updateError && (
@@ -368,22 +234,21 @@ export default function AdminCitas() {
                               </span>
                             </div>
 
-                              <div className="text-sm text-gray-500 mt-2">
-                                <span data-testid="cita-servicios-count">
-                                  {cita.servicio_ids.length} servicio{cita.servicio_ids.length !== 1 ? 's' : ''}
+                            <div className="text-sm text-gray-500 mt-2">
+                              <span data-testid="cita-servicios-count">
+                                {cita.servicio_ids.length} servicio{cita.servicio_ids.length !== 1 ? 's' : ''}
+                              </span>
+                              {cita.puntos_utilizados > 0 && (
+                                <span className="ml-2 px-2 py-0.5 bg-red-50 text-red-600 rounded-full text-xs font-bold">
+                                  -{cita.puntos_utilizados} pts canjeados
                                 </span>
-                                {cita.puntos_utilizados > 0 && (
-                                  <span className="ml-2 px-2 py-0.5 bg-red-50 text-red-600 rounded-full text-xs font-bold">
-                                    -{cita.puntos_utilizados} pts canjeados
-                                  </span>
-                                )}
-                                {cita.puntos_ganados > 0 && (
-                                  <span className="ml-2 px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-bold">
-                                    +{cita.puntos_ganados} pts otorgados
-                                  </span>
-                                )}
-                              </div>
-
+                              )}
+                              {cita.puntos_ganados > 0 && (
+                                <span className="ml-2 px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-bold">
+                                  +{cita.puntos_ganados} pts otorgados
+                                </span>
+                              )}
+                            </div>
 
                             {cita.notas && (
                               <p className="mt-3 text-sm text-gray-600 bg-gray-50 p-3 rounded-lg">
@@ -399,6 +264,16 @@ export default function AdminCitas() {
                                 Esperando confirmación
                               </div>
                             )}
+
+                            <Link to={`/admin/citas/${cita.id}/editar`}>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                              >
+                                <Pencil size={16} className="mr-2" />
+                                Editar
+                              </Button>
+                            </Link>
 
                             {(cita.estado === 'pendiente' || cita.estado === 'confirmada') && (
                               <Button
@@ -482,193 +357,6 @@ export default function AdminCitas() {
             </div>
           )}
         </div>
-
-        {modalOpen && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-            <Card className="w-full max-w-2xl max-h-[90vh] flex flex-col">
-              <CardContent className="p-0 flex flex-col h-full overflow-hidden">
-                <div className="p-6 border-b border-gray-100 flex items-center justify-between shrink-0">
-                  <div>
-                    <h2 className="text-xl font-semibold text-gray-900">Nueva Cita</h2>
-                    <p className="text-sm text-gray-500">Crea una cita para una clienta</p>
-                  </div>
-                  <Button type="button" variant="outline" onClick={closeModal}>
-                    Cerrar
-                  </Button>
-                </div>
-
-                <form onSubmit={handleCreateCita} className="flex flex-col h-full overflow-hidden">
-                  <div className="flex-1 overflow-y-auto p-6 space-y-4">
-                    {modalError && (
-                      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                        {modalError}
-                      </div>
-                    )}
-
-                    <Select
-                      id="clienta_id"
-                      label="Clienta"
-                      options={clientas.map((c) => ({
-                        value: c.id,
-                        label: `${c.nombre} ${c.apellido}`
-                      }))}
-                      value={formData.clienta_id}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, clienta_id: e.target.value }))}
-                      required
-                    />
-
-                    <Input
-                      id="fecha_hora"
-                      type="datetime-local"
-                      label="Fecha y Hora"
-                      value={formData.fecha_hora}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, fecha_hora: e.target.value }))}
-                      required
-                    />
-
-                    <div className="bg-gray-50 p-4 rounded-lg border border-gray-200">
-                      <div className="flex items-center justify-between mb-2">
-                        <label className="text-sm font-medium text-gray-700">Resumen de la cita</label>
-                        <div className="text-xs text-gray-500">
-                          Puntos disponibles: <span className="font-semibold">{formData.clienta_id ? getClientaById(formData.clienta_id)?.puntos ?? 0 : 0} pts</span>
-                        </div>
-                      </div>
-                      <div className="space-y-1">
-                        <div className="flex justify-between text-sm">
-                          <span className="text-gray-600">Puntos a descontar (canjes):</span>
-                          <span data-testid="puntos-descontar" className="font-bold text-red-600">-{getPuntosUtilizados(formData.items)} pts</span>
-                        </div>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-gray-600">Puntos a ganar (compras):</span>
-                          <span data-testid="puntos-ganar" className="font-bold text-primary">+{getPuntosGanados(formData.items)} pts</span>
-                        </div>
-                        <div className="flex justify-between text-sm pt-2 mt-2 border-t border-gray-200">
-                          <span className="font-medium text-gray-900">Total a pagar:</span>
-                          <span data-testid="precio-total" className="font-bold text-gray-900">${getPrecioTotal(formData.items)}</span>
-                        </div>
-                      </div>
-                      <p className="mt-2 text-xs text-gray-500 italic">
-                        Los puntos se actualizarán en la cuenta de la clienta al completar la cita.
-                      </p>
-                    </div>
-
-                    <div>
-                      <div className="flex items-center justify-between mb-2">
-                        <label className="block text-sm font-medium text-gray-700">Servicios</label>
-                      </div>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3" id="servicios-list-container" data-testid="servicios-list">
-                        {servicios.map((servicio) => {
-                          const item = formData.items.find(it => it.servicio_id === servicio.id);
-                          const checked = !!item;
-                          
-                          return (
-                            <div
-                              key={servicio.id}
-                              data-testid={`servicio-item-${servicio.nombre}`}
-                              className={
-                                'flex flex-col gap-2 rounded-lg border p-3 transition-colors ' +
-                                (checked
-                                  ? 'border-primary bg-primary/5'
-                                  : 'border-gray-200 hover:bg-gray-50')
-                              }
-                            >
-                              <div className="flex items-center gap-3">
-                                <input
-                                  id={`check-${servicio.id}`}
-                                  data-testid={`check-${servicio.nombre}`}
-                                  type="checkbox"
-                                  checked={checked}
-                                  onChange={() => toggleServicio(servicio.id)}
-                                  className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
-                                />
-                                <label
-                                  htmlFor={`check-${servicio.id}`}
-                                  className="flex-1 min-w-0 cursor-pointer"
-                                >
-                                  <div className="flex items-center justify-between gap-2">
-                                    <div className="font-medium text-gray-900 truncate" data-testid="servicio-nombre">
-                                      {servicio.nombre}
-                                    </div>
-                                    <div className="text-sm font-semibold text-gray-900 shrink-0">
-                                      ${servicio.precio}
-                                    </div>
-                                  </div>
-                                  <div className="text-xs text-gray-500">
-                                    {servicio.puntos_otorgados} pts otorgados
-                                    {servicio.puntos_requeridos && ` | ${servicio.puntos_requeridos} pts req`}
-                                  </div>
-                                </label>
-                              </div>
-
-                              {checked && (
-                                <div className="flex gap-2 ml-7 mt-1">
-                                  <button
-                                    type="button"
-                                    data-testid="btn-comprado"
-                                    onClick={() => setItemTipo(servicio.id, 'comprado')}
-                                    className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-                                      item.tipo === 'comprado'
-                                        ? 'bg-primary text-white border-primary'
-                                        : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
-                                    }`}
-                                  >
-                                    Compra
-                                  </button>
-                                  {servicio.puntos_requeridos ? (
-                                    <button
-                                      type="button"
-                                      data-testid="btn-canjeado"
-                                      onClick={() => setItemTipo(servicio.id, 'canjeado')}
-                                      disabled={!formData.clienta_id || (getClientaById(formData.clienta_id)?.puntos ?? 0) < (servicio.puntos_requeridos ?? 0)}
-                                      className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-                                        item.tipo === 'canjeado'
-                                          ? 'bg-accent text-white border-accent'
-                                          : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed'
-                                      }`}
-                                      title={!formData.clienta_id ? 'Selecciona una clienta primero' : (getClientaById(formData.clienta_id)?.puntos ?? 0) < (servicio.puntos_requeridos ?? 0) ? 'Puntos insuficientes' : ''}
-                                    >
-                                      Canje
-                                    </button>
-                                  ) : (
-                                    <span data-testid="no-canjeable" className="text-[10px] text-gray-400 self-center">No canjeable</span>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                      {servicios.length === 0 && (
-                        <div className="text-sm text-gray-500">No hay servicios cargados.</div>
-                      )}
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Notas (opcional)</label>
-                      <textarea
-                        id="notas"
-                        rows={3}
-                        value={formData.notas}
-                        onChange={(e) => setFormData((prev) => ({ ...prev, notas: e.target.value }))}
-                        placeholder="Ej: traer diseño de referencia..."
-                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="p-6 border-t border-gray-100 flex justify-end gap-3 shrink-0">
-                    <Button type="button" variant="outline" onClick={closeModal} disabled={submitting}>
-                      Cancelar
-                    </Button>
-                    <Button type="submit" loading={submitting}>
-                      Crear Cita
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/EditarCita.tsx
+++ b/frontend/src/pages/admin/EditarCita.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { citasService } from '../../services/citas';
+import type { Cita } from '@fidelity-card/shared';
+import CitaForm, { type CitaFormData } from './CitaForm';
+import { Card, CardContent } from '../../components/Card';
+import { Button } from '../../components/Button';
+import { ArrowLeft } from 'lucide-react';
+
+export default function EditarCita() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [cita, setCita] = useState<Cita | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setNotFound(true);
+      setLoading(false);
+      return;
+    }
+
+    async function loadCita() {
+      try {
+        const citaData = await citasService.getById(id!);
+        setCita(citaData);
+      } catch (err) {
+        console.error('Error al cargar cita:', err);
+        setNotFound(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadCita();
+  }, [id]);
+
+  async function handleSubmit(data: CitaFormData) {
+    if (!id) return;
+
+    setError(null);
+
+    if (data.items.length === 0) {
+      setError('Selecciona al menos un servicio.');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await citasService.updateFull(id, {
+        items: data.items,
+        fecha_hora: data.fecha_hora,
+        notas: data.notas || undefined,
+      });
+      navigate('/admin/citas');
+    } catch (err) {
+      console.error('Error al actualizar cita:', err);
+      setError('No se pudo actualizar la cita. Intenta nuevamente.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (notFound || !cita) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Cita no encontrada</h2>
+          <p className="text-gray-600 mb-4">La cita que buscas no existe o fue eliminada.</p>
+          <Button onClick={() => navigate('/admin/citas')}>
+            Volver a Citas
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const existingItems = cita.items && cita.items.length > 0
+    ? cita.items
+    : cita.servicio_ids.map((sid) => ({ servicio_id: sid, tipo: 'comprado' as const }));
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4">
+        <div className="mb-6">
+          <Button type="button" variant="outline" onClick={() => navigate('/admin/citas')}>
+            <ArrowLeft size={18} className="mr-2" />
+            Volver a Citas
+          </Button>
+        </div>
+
+        <Card>
+          <CardContent className="p-0">
+            <div className="p-6 border-b border-gray-100">
+              <h1 className="text-xl font-semibold text-gray-900">Editar Cita</h1>
+              <p className="text-sm text-gray-500">Modifica los detalles de la cita</p>
+            </div>
+            <div className="p-6">
+              <CitaForm
+                initialData={cita}
+                initialItems={existingItems}
+                onSubmit={handleSubmit}
+                submitting={submitting}
+                error={error}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/NuevaCita.tsx
+++ b/frontend/src/pages/admin/NuevaCita.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { citasService } from '../../services/citas';
+import CitaForm, { type CitaFormData } from './CitaForm';
+import { Card, CardContent } from '../../components/Card';
+import { Button } from '../../components/Button';
+import { ArrowLeft } from 'lucide-react';
+
+export default function NuevaCita() {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(data: CitaFormData) {
+    setError(null);
+
+    if (!data.clienta_id) {
+      setError('Selecciona una clienta.');
+      return;
+    }
+    if (data.items.length === 0) {
+      setError('Selecciona al menos un servicio.');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await citasService.create({
+        clienta_id: data.clienta_id,
+        items: data.items,
+        fecha_hora: data.fecha_hora,
+        notas: data.notas || undefined,
+      });
+      navigate('/admin/citas');
+    } catch (err) {
+      console.error('Error al crear cita:', err);
+      setError('No se pudo crear la cita. Intenta nuevamente.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4">
+        <div className="mb-6">
+          <Button type="button" variant="outline" onClick={() => navigate('/admin/citas')}>
+            <ArrowLeft size={18} className="mr-2" />
+            Volver a Citas
+          </Button>
+        </div>
+
+        <Card>
+          <CardContent className="p-0">
+            <div className="p-6 border-b border-gray-100">
+              <h1 className="text-xl font-semibold text-gray-900">Nueva Cita</h1>
+              <p className="text-sm text-gray-500">Crea una cita para una clienta</p>
+            </div>
+            <div className="p-6">
+              <CitaForm
+                onSubmit={handleSubmit}
+                submitting={submitting}
+                error={error}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/citas.ts
+++ b/frontend/src/services/citas.ts
@@ -1,4 +1,4 @@
-import { del, get, patch, post } from './api';
+import { del, get, patch, post, put } from './api';
 import type { Cita } from '@fidelity-card/shared';
 
 type CitaItemInput = {
@@ -18,9 +18,8 @@ export const citasService = {
     return get<Cita[]>('/api/citas');
   },
 
-  async getById(id: string): Promise<Cita | null> {
-    const citas = await get<Cita[]>('/api/citas');
-    return citas.find((cita) => cita.id === id) ?? null;
+  async getById(id: string): Promise<Cita> {
+    return get<Cita>(`/api/citas/${id}`);
   },
 
   async getByClienta(clientaId: string): Promise<Cita[]> {
@@ -33,6 +32,14 @@ export const citasService = {
 
   async update(id: string, updates: Partial<Cita>): Promise<Cita> {
     return patch<Cita>(`/api/citas/${id}`, updates);
+  },
+
+  async updateFull(id: string, data: {
+    items: CitaItemInput[];
+    fecha_hora: string;
+    notas?: string;
+  }): Promise<Cita> {
+    return put<Cita>(`/api/citas/${id}`, data);
   },
 
   async delete(id: string): Promise<void> {

--- a/packages/shared/src/types/entities.ts
+++ b/packages/shared/src/types/entities.ts
@@ -22,11 +22,17 @@ export interface Servicio {
   created_at: string;
 }
 
+export type CitaItem = {
+  servicio_id: string;
+  tipo: 'comprado' | 'canjeado';
+};
+
 export interface Cita {
   id: string;
   clienta_id: string;
   servicio_ids: string[];
   servicios?: Servicio[];
+  items?: CitaItem[];
   fecha_hora: string;
   puntos_ganados: number;
   puntos_utilizados: number;


### PR DESCRIPTION
- Add CitaItem type and items field to shared entities
- Extend toPublicCita transformer to return per-item tipo
- Add GET/PUT /api/citas/:id backend endpoints
- Extract shared CitaForm component from inline modal
- Create /admin/citas/nueva and /admin/citas/:id/editar routes
- Remove modal from Citas.tsx, add Link-based create/edit navigation
- Both routes protected with RequireAdmin

Closes #29