### PR TITLE
refactor(backend): extract config, error handler, add premios transformer

### DIFF
--- a/backend/src/config/auth.ts
+++ b/backend/src/config/auth.ts
@@ -1,0 +1,10 @@
+import type { AuthContextOptions } from '../modules/auth-context';
+
+import type { Env } from './env';
+
+export function getAuthOptions(env: Env): AuthContextOptions {
+  return {
+    jwtSecret: env.JWT_SECRET,
+    nodeEnv: env.NODE_ENV,
+  };
+}

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,27 @@
+export type Env = {
+  PORT: number;
+  NODE_ENV: 'development' | 'test' | 'production';
+  JWT_SECRET: string;
+};
+
+export function getEnv(): Env {
+  const portRaw = process.env.PORT;
+  const port = portRaw ? Number(portRaw) : 3001;
+
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`Invalid PORT: ${String(portRaw)}`);
+  }
+
+  const nodeEnvRaw = process.env.NODE_ENV;
+  const nodeEnv = (nodeEnvRaw || 'development') as Env['NODE_ENV'];
+  if (!['development', 'test', 'production'].includes(nodeEnv)) {
+    throw new Error(`Invalid NODE_ENV: ${String(nodeEnvRaw)}`);
+  }
+
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    throw new Error('JWT_SECRET is required');
+  }
+
+  return { PORT: port, NODE_ENV: nodeEnv, JWT_SECRET: jwtSecret };
+}

--- a/backend/src/domain/transformers/premios.ts
+++ b/backend/src/domain/transformers/premios.ts
@@ -1,0 +1,17 @@
+import type { PublicPremio } from '../types/premios';
+
+export function toPublicPremio(row: {
+  id: string;
+  nombre: string;
+  descripcion: string | null;
+  puntos_requeridos: number;
+  activo: boolean;
+}): PublicPremio {
+  return {
+    id: row.id,
+    nombre: row.nombre,
+    descripcion: row.descripcion || '',
+    puntos_requeridos: row.puntos_requeridos,
+    activo: row.activo,
+  };
+}

--- a/backend/src/domain/types/premios.ts
+++ b/backend/src/domain/types/premios.ts
@@ -1,0 +1,7 @@
+export type PublicPremio = {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  puntos_requeridos: number;
+  activo: boolean;
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,8 @@
 import { Elysia } from 'elysia';
 
+import { getEnv } from './config/env';
+import { getAuthOptions } from './config/auth';
+import { createErrorHandler } from './middleware/error-handler';
 import { authContextModule } from './modules/auth-context';
 import { registerAuthRoutes } from './modules/auth';
 import { registerServiciosRoutes } from './modules/servicios';
@@ -8,57 +11,11 @@ import { registerProfilesRoutes } from './modules/profiles';
 import { registerReferidosRoutes } from './modules/referidos';
 import { registerPremiosRoutes } from './modules/premios';
 
-type Env = {
-  PORT: number;
-  NODE_ENV: 'development' | 'test' | 'production';
-  JWT_SECRET: string;
-};
-
-function getEnv(): Env {
-  const portRaw = process.env.PORT;
-  const port = portRaw ? Number(portRaw) : 3001;
-
-  if (!Number.isFinite(port) || port <= 0) {
-    throw new Error(`Invalid PORT: ${String(portRaw)}`);
-  }
-
-  const nodeEnvRaw = process.env.NODE_ENV;
-  const nodeEnv = (nodeEnvRaw || 'development') as Env['NODE_ENV'];
-  if (!['development', 'test', 'production'].includes(nodeEnv)) {
-    throw new Error(`Invalid NODE_ENV: ${String(nodeEnvRaw)}`);
-  }
-
-  const jwtSecret = process.env.JWT_SECRET;
-  if (!jwtSecret) {
-    throw new Error('JWT_SECRET is required');
-  }
-
-  return { PORT: port, NODE_ENV: nodeEnv, JWT_SECRET: jwtSecret };
-}
-
 const env = getEnv();
-
-const authOptions = {
-  jwtSecret: env.JWT_SECRET,
-  nodeEnv: env.NODE_ENV,
-} as const;
+const authOptions = getAuthOptions(env);
 
 const app = new Elysia()
-  .onError(({ code, error, set }) => {
-    if (code === 'VALIDATION') {
-      set.status = 422;
-      return { error: 'validation_error' };
-    }
-
-    if (env.NODE_ENV !== 'test') {
-      console.error(`[api] error code=${code}`, error);
-    }
-
-    set.status = 500;
-    return {
-      error: 'internal_server_error'
-    };
-  })
+  .onError(createErrorHandler(env.NODE_ENV))
   .use(authContextModule(authOptions))
   .get('/api/health', () => ({ ok: true }))
   .get('/api/_admin', ({ auth, status }) => {

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -1,0 +1,19 @@
+import type { ErrorHandler } from 'elysia';
+
+export function createErrorHandler(nodeEnv: string): ErrorHandler {
+  return ({ code, error, set }) => {
+    if (code === 'VALIDATION') {
+      set.status = 422;
+      return { error: 'validation_error' };
+    }
+
+    if (nodeEnv !== 'test') {
+      console.error(`[api] error code=${code}`, error);
+    }
+
+    set.status = 500;
+    return {
+      error: 'internal_server_error',
+    };
+  };
+}

--- a/backend/src/modules/premios.handlers.ts
+++ b/backend/src/modules/premios.handlers.ts
@@ -2,6 +2,7 @@ import { asc, eq } from 'drizzle-orm';
 
 import { db as defaultDb } from '../db';
 import { premios } from '../db/schema';
+import { toPublicPremio } from '../domain/transformers/premios';
 import type { StatusHelper } from '../domain/types/http';
 
 import { requireAdmin } from './auth-context';
@@ -50,8 +51,8 @@ export type PremioDeleteCtx = {
 export function createPremiosHttpHandlers(deps: PremiosDeps) {
   return {
     listPremios: async () => {
-      // Listamos todos por ahora (el FE puede filtrar por activo si desea)
-      return await deps.db.select().from(premios).orderBy(asc(premios.nombre));
+      const rows = await deps.db.select().from(premios).orderBy(asc(premios.nombre));
+      return rows.map(toPublicPremio);
     },
 
     createPremio: async (ctx: unknown) => {
@@ -76,7 +77,7 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
       }
 
       set.status = 201;
-      return row;
+      return toPublicPremio(row);
     },
 
     patchPremio: async (ctx: unknown) => {
@@ -103,7 +104,7 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
         return { error: 'not_found' };
       }
 
-      return row;
+      return toPublicPremio(row);
     },
 
     deletePremio: async (ctx: unknown) => {

--- a/backend/src/modules/referidos.routes.ts
+++ b/backend/src/modules/referidos.routes.ts
@@ -1,0 +1,62 @@
+import { t } from 'elysia';
+import type { AnyElysia } from 'elysia';
+
+import { db as defaultDb } from '../db';
+
+import { createReferidosHandlers } from './referidos.handlers';
+
+/** Registra rutas HTTP para referidos y puntos. */
+export function registerReferidosRoutes(app: AnyElysia) {
+  const handlers = createReferidosHandlers({ db: defaultDb });
+
+  return app
+    .get(
+      '/api/referidos',
+      handlers.list,
+      {
+        query: t.Object({
+          referente_id: t.Optional(t.String({ format: 'uuid' })),
+        }),
+      }
+    )
+    .post(
+      '/api/referidos',
+      handlers.create,
+      {
+        body: t.Object({
+          referente_id: t.String({ format: 'uuid' }),
+          referida_id: t.String({ format: 'uuid' }),
+          puntos_ganados: t.Integer({ minimum: 0 }),
+        }),
+      }
+    )
+    .get(
+      '/api/puntos/top',
+      handlers.puntosTop,
+      {
+        query: t.Object({
+          limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
+        }),
+      }
+    )
+    .post(
+      '/api/puntos/sumar',
+      handlers.sumarPuntos,
+      {
+        body: t.Object({
+          profile_id: t.String({ format: 'uuid' }),
+          cantidad: t.Integer({ minimum: 0 }),
+        }),
+      }
+    )
+    .post(
+      '/api/puntos/restar',
+      handlers.restarPuntos,
+      {
+        body: t.Object({
+          profile_id: t.String({ format: 'uuid' }),
+          cantidad: t.Integer({ minimum: 0 }),
+        }),
+      }
+    );
+}

--- a/backend/src/modules/referidos.ts
+++ b/backend/src/modules/referidos.ts
@@ -1,61 +1,11 @@
-import { t } from 'elysia';
-import type { AnyElysia } from 'elysia';
-
-import { db as defaultDb } from '../db';
-
-import { createReferidosHandlers } from './referidos.handlers';
-
-export function registerReferidosRoutes(app: AnyElysia) {
-  const handlers = createReferidosHandlers({ db: defaultDb });
-
-  return app
-    .get(
-      '/api/referidos',
-      handlers.list,
-      {
-        query: t.Object({
-          referente_id: t.Optional(t.String({ format: 'uuid' })),
-        }),
-      }
-    )
-    .post(
-      '/api/referidos',
-      handlers.create,
-      {
-        body: t.Object({
-          referente_id: t.String({ format: 'uuid' }),
-          referida_id: t.String({ format: 'uuid' }),
-          puntos_ganados: t.Integer({ minimum: 0 }),
-        }),
-      }
-    )
-    .get(
-      '/api/puntos/top',
-      handlers.puntosTop,
-      {
-        query: t.Object({
-          limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
-        }),
-      }
-    )
-    .post(
-      '/api/puntos/sumar',
-      handlers.sumarPuntos,
-      {
-        body: t.Object({
-          profile_id: t.String({ format: 'uuid' }),
-          cantidad: t.Integer({ minimum: 0 }),
-        }),
-      }
-    )
-    .post(
-      '/api/puntos/restar',
-      handlers.restarPuntos,
-      {
-        body: t.Object({
-          profile_id: t.String({ format: 'uuid' }),
-          cantidad: t.Integer({ minimum: 0 }),
-        }),
-      }
-    );
-}
+export { registerReferidosRoutes } from './referidos.routes';
+export { createReferidosHandlers } from './referidos.handlers';
+export type {
+  ReferidosDeps,
+  ReferidosListCtx,
+  ReferidosCreateCtx,
+  PuntosTopQuery,
+  PuntosTopCtx,
+  PuntosAdjustBody,
+  PuntosAdjustCtx,
+} from './referidos.handlers';

--- a/backend/src/utils/iso.ts
+++ b/backend/src/utils/iso.ts
@@ -1,1 +1,0 @@
-export { asIsoString } from '../domain/transformers/iso';


### PR DESCRIPTION
## Summary
- Extract `Env` type + `getEnv()` to `config/env.ts`, `authOptions` to `config/auth.ts`, error handler to `middleware/error-handler.ts` — `index.ts` reduced from 81 to 38 lines of clean assembly
- Delete `utils/iso.ts` — was a 1-line re-export with zero references
- Split `referidos.ts` into `referidos.routes.ts` + barrel file, matching the `*.routes.ts` + `*.handlers.ts` convention
- Add `toPublicPremio()` transformer — premios was the only module returning raw DB rows

Closes #40, Closes #43, closes #45, closes #38