### PR TITLE
refactor(frontend): create useAdminList hook to eliminate CRUD boilerplate

### DIFF
--- a/frontend/src/hooks/useAdminList.ts
+++ b/frontend/src/hooks/useAdminList.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface UseAdminListConfig<T, TForm> {
+  fetchFn: () => Promise<T[]>;
+  filterFn: (items: T[], search: string) => T[];
+  createFn: (data: TForm) => Promise<void>;
+  updateFn: (id: string, data: TForm) => Promise<void>;
+  deleteFn: (id: string) => Promise<void>;
+  initialFormData: TForm;
+  mapItemToForm: (item: T) => TForm;
+  itemName: string;
+}
+
+export function useAdminList<T extends { id: string }, TForm>(
+  config: UseAdminListConfig<T, TForm>
+) {
+  const {
+    fetchFn,
+    filterFn,
+    createFn,
+    updateFn,
+    deleteFn,
+    initialFormData,
+    mapItemToForm,
+    itemName,
+  } = config;
+
+  const [items, setItems] = useState<T[]>([]);
+  const [filteredItems, setFilteredItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [modalError, setModalError] = useState<string | null>(null);
+  const [editingItem, setEditingItem] = useState<T | null>(null);
+  const [formData, setFormData] = useState<TForm>(initialFormData);
+
+  useEffect(() => {
+    async function loadItems() {
+      try {
+        const data = await fetchFn();
+        setItems(data);
+        setFilteredItems(data);
+      } catch (error) {
+        console.error(`Error al cargar ${itemName}:`, error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadItems();
+  }, [fetchFn, itemName]);
+
+  useEffect(() => {
+    const filtered = filterFn(items, searchTerm);
+    setFilteredItems(filtered);
+  }, [searchTerm, items, filterFn]);
+
+  const refreshItems = useCallback(async () => {
+    const data = await fetchFn();
+    setItems(data);
+    setFilteredItems(data);
+  }, [fetchFn]);
+
+  function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
+    setSearchTerm(e.target.value);
+  }
+
+  function openModal(item?: T) {
+    if (item) {
+      setEditingItem(item);
+      setFormData(mapItemToForm(item));
+    } else {
+      setEditingItem(null);
+      setFormData(initialFormData);
+    }
+    setModalOpen(true);
+  }
+
+  function closeModal() {
+    setModalOpen(false);
+    setSubmitting(false);
+    setModalError(null);
+    setEditingItem(null);
+    setFormData(initialFormData);
+  }
+
+  async function handleSubmit(
+    e: React.FormEvent,
+    transformData: (data: TForm) => TForm
+  ) {
+    e.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    setModalError(null);
+
+    try {
+      const transformedData = transformData(formData);
+
+      if (editingItem) {
+        await updateFn(editingItem.id, transformedData);
+      } else {
+        await createFn(transformedData);
+      }
+
+      await refreshItems();
+      closeModal();
+    } catch (error: unknown) {
+      console.error(`Error al guardar ${itemName}:`, error);
+      const message =
+        error instanceof Error ? error.message : `No se pudo guardar el ${itemName}.`;
+      setModalError(`Error: ${message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`¿Estás segura de que deseas eliminar este ${itemName}?`)) return;
+
+    try {
+      await deleteFn(id);
+      await refreshItems();
+    } catch (error) {
+      console.error(`Error al eliminar ${itemName}:`, error);
+    }
+  }
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    const { id, name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [id || name]: value,
+    }));
+  }
+
+  function handleCheckboxChange(
+    e: React.ChangeEvent<HTMLInputElement>
+  ) {
+    const { id, checked } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [id]: checked,
+    }));
+  }
+
+  return {
+    items: filteredItems,
+    loading,
+    searchTerm,
+    modalOpen,
+    submitting,
+    modalError,
+    editingItem,
+    formData,
+    setFormData,
+    handleSearch,
+    openModal,
+    closeModal,
+    handleSubmit,
+    handleDelete,
+    handleChange,
+    handleCheckboxChange,
+    refreshItems,
+  };
+}

--- a/frontend/src/hooks/useAdminList.ts
+++ b/frontend/src/hooks/useAdminList.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 
 export interface UseAdminListConfig<T, TForm> {
   fetchFn: () => Promise<T[]>;
@@ -26,7 +26,6 @@ export function useAdminList<T extends { id: string }, TForm>(
   } = config;
 
   const [items, setItems] = useState<T[]>([]);
-  const [filteredItems, setFilteredItems] = useState<T[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
@@ -40,7 +39,6 @@ export function useAdminList<T extends { id: string }, TForm>(
       try {
         const data = await fetchFn();
         setItems(data);
-        setFilteredItems(data);
       } catch (error) {
         console.error(`Error al cargar ${itemName}:`, error);
       } finally {
@@ -50,16 +48,12 @@ export function useAdminList<T extends { id: string }, TForm>(
     loadItems();
   }, [fetchFn, itemName]);
 
-  useEffect(() => {
-    const filtered = filterFn(items, searchTerm);
-    setFilteredItems(filtered);
-  }, [searchTerm, items, filterFn]);
+  const filteredItems = filterFn(items, searchTerm);
 
-  const refreshItems = useCallback(async () => {
+  async function refreshItems() {
     const data = await fetchFn();
     setItems(data);
-    setFilteredItems(data);
-  }, [fetchFn]);
+  }
 
   function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
     setSearchTerm(e.target.value);

--- a/frontend/src/pages/admin/Premios.tsx
+++ b/frontend/src/pages/admin/Premios.tsx
@@ -1,122 +1,79 @@
-import { useState, useEffect } from 'react';
+import { useCallback } from 'react';
 import { premiosService } from '../../services/premios';
 import type { Premio } from '@fidelity-card/shared';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/Card';
 import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 import { Gift, Plus, Edit, Trash2, Search, Star, CheckCircle2, XCircle } from 'lucide-react';
+import { useAdminList } from '../../hooks/useAdminList';
+
+interface PremioFormData {
+  nombre: string;
+  descripcion: string;
+  puntos_requeridos: string;
+  activo: boolean;
+}
+
+const INITIAL_FORM: PremioFormData = {
+  nombre: '',
+  descripcion: '',
+  puntos_requeridos: '',
+  activo: true,
+};
 
 export default function AdminPremios() {
-  const [premios, setPremios] = useState<Premio[]>([]);
-  const [filteredPremios, setFilteredPremios] = useState<Premio[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editingPremio, setEditingPremio] = useState<Premio | null>(null);
-  const [formData, setFormData] = useState({
-    nombre: '',
-    descripcion: '',
-    puntos_requeridos: '',
-    activo: true
-  });
-
-  useEffect(() => {
-    async function loadPremios() {
-      try {
-        const data = await premiosService.getAll();
-        setPremios(data);
-        setFilteredPremios(data);
-      } catch (error) {
-        console.error('Error al cargar premios:', error);
-      } finally {
-        setLoading(false);
-      }
-    }
-    loadPremios();
-  }, []);
-
-  useEffect(() => {
-    const filtered = premios.filter(premio =>
-      premio.nombre.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredPremios(filtered);
-  }, [searchTerm, premios]);
-
-  function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
-    setSearchTerm(e.target.value);
-  }
-
-  function openModal(premio?: Premio) {
-    if (premio) {
-      setEditingPremio(premio);
-      setFormData({
-        nombre: premio.nombre,
-        descripcion: premio.descripcion || '',
-        puntos_requeridos: premio.puntos_requeridos.toString(),
-        activo: premio.activo
+  const {
+    items: premios,
+    loading,
+    searchTerm,
+    modalOpen,
+    editingItem: editingPremio,
+    formData,
+    handleSearch,
+    openModal,
+    closeModal,
+    handleSubmit,
+    handleDelete,
+    handleChange,
+    handleCheckboxChange,
+  } = useAdminList<Premio, PremioFormData>({
+    fetchFn: useCallback(() => premiosService.getAll(), []),
+    filterFn: useCallback(
+      (items: Premio[], search: string) =>
+        items.filter(p => p.nombre.toLowerCase().includes(search.toLowerCase())),
+      []
+    ),
+    createFn: useCallback(async (data: PremioFormData) => {
+      await premiosService.create({
+        nombre: data.nombre,
+        descripcion: data.descripcion,
+        puntos_requeridos: parseInt(data.puntos_requeridos),
+        activo: data.activo,
       });
-    } else {
-      setEditingPremio(null);
-      setFormData({
-        nombre: '',
-        descripcion: '',
-        puntos_requeridos: '',
-        activo: true
+    }, []),
+    updateFn: useCallback(async (id: string, data: PremioFormData) => {
+      await premiosService.update(id, {
+        nombre: data.nombre,
+        descripcion: data.descripcion,
+        puntos_requeridos: parseInt(data.puntos_requeridos),
+        activo: data.activo,
       });
-    }
-    setModalOpen(true);
-  }
-
-  function closeModal() {
-    setModalOpen(false);
-    setEditingPremio(null);
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    try {
-      const premioData = {
-        nombre: formData.nombre,
-        descripcion: formData.descripcion,
-        puntos_requeridos: parseInt(formData.puntos_requeridos),
-        activo: formData.activo
-      };
-
-      if (editingPremio) {
-        await premiosService.update(editingPremio.id, premioData);
-      } else {
-        await premiosService.create(premioData);
-      }
-
-      const data = await premiosService.getAll();
-      setPremios(data);
-      setFilteredPremios(data);
-      closeModal();
-    } catch (error) {
-      console.error('Error al guardar premio:', error);
-    }
-  }
-
-  async function handleDelete(id: string) {
-    if (!confirm('¿Estás segura de que deseas eliminar este premio?')) return;
-
-    try {
+    }, []),
+    deleteFn: useCallback(async (id: string) => {
       await premiosService.delete(id);
-      const data = await premiosService.getAll();
-      setPremios(data);
-      setFilteredPremios(data);
-    } catch (error) {
-      console.error('Error al eliminar premio:', error);
-    }
-  }
-
-  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    const { id, value, type } = e.target as HTMLInputElement;
-    setFormData({
-      ...formData,
-      [id]: type === 'checkbox' ? (e.target as HTMLInputElement).checked : value
-    });
-  }
+    }, []),
+    initialFormData: INITIAL_FORM,
+    mapItemToForm: useCallback(
+      (p: Premio): PremioFormData => ({
+        nombre: p.nombre,
+        descripcion: p.descripcion || '',
+        puntos_requeridos: p.puntos_requeridos.toString(),
+        activo: p.activo,
+      }),
+      []
+    ),
+    itemName: 'premio',
+  });
 
   if (loading) {
     return (
@@ -163,11 +120,11 @@ export default function AdminPremios() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Gift size={24} className="text-primary" />
-              Premios ({filteredPremios.length})
+              Premios ({premios.length})
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {filteredPremios.length === 0 ? (
+            {premios.length === 0 ? (
               <div className="text-center py-12">
                 <Gift size={48} className="mx-auto text-gray-400 mb-4" />
                 <p className="text-gray-500">
@@ -176,7 +133,7 @@ export default function AdminPremios() {
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {filteredPremios.map((premio) => (
+                {premios.map((premio) => (
                   <div
                     key={premio.id}
                     className={`bg-white rounded-lg border p-4 hover:shadow-md transition-shadow ${
@@ -249,7 +206,7 @@ export default function AdminPremios() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
+                <form onSubmit={(e) => handleSubmit(e, (d) => d)} className="space-y-4">
                   <Input
                     id="nombre"
                     label="Nombre del Premio"
@@ -286,7 +243,7 @@ export default function AdminPremios() {
                       id="activo"
                       type="checkbox"
                       checked={formData.activo}
-                      onChange={handleChange}
+                      onChange={handleCheckboxChange}
                       className="w-4 h-4 text-primary border-gray-300 rounded focus:ring-primary"
                     />
                     <label htmlFor="activo" className="text-sm font-medium text-gray-700">

--- a/frontend/src/pages/admin/Servicios.tsx
+++ b/frontend/src/pages/admin/Servicios.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback } from 'react';
 import { serviciosService } from '../../services/servicios';
 import type { Servicio } from '@fidelity-card/shared';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/Card';
@@ -6,149 +6,92 @@ import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 import { Gem, Plus, Edit, Trash2, Search, Clock, Star, Gift } from 'lucide-react';
 import { formatearPrecio } from '../../utils';
+import { useAdminList } from '../../hooks/useAdminList';
+
+interface ServicioFormData {
+  nombre: string;
+  descripcion: string;
+  precio: string;
+  duracion_min: string;
+  puntos_otorgados: string;
+  puntos_requeridos: string;
+}
+
+const INITIAL_FORM: ServicioFormData = {
+  nombre: '',
+  descripcion: '',
+  precio: '',
+  duracion_min: '',
+  puntos_otorgados: '',
+  puntos_requeridos: '',
+};
 
 export default function AdminServicios() {
-  const [servicios, setServicios] = useState<Servicio[]>([]);
-  const [filteredServicios, setFilteredServicios] = useState<Servicio[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [modalOpen, setModalOpen] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [modalError, setModalError] = useState<string | null>(null);
-  const [editingServicio, setEditingServicio] = useState<Servicio | null>(null);
-  const [formData, setFormData] = useState({
-    nombre: '',
-    descripcion: '',
-    precio: '',
-    duracion_min: '',
-    puntos_otorgados: '',
-    puntos_requeridos: ''
-  });
-
-  useEffect(() => {
-    async function loadServicios() {
-      try {
-        const data = await serviciosService.getAll();
-        setServicios(data);
-        setFilteredServicios(data);
-      } catch (error) {
-        console.error('Error al cargar servicios:', error);
-      } finally {
-        setLoading(false);
-      }
-    }
-    loadServicios();
-  }, []);
-
-  useEffect(() => {
-    const filtered = servicios.filter(servicio =>
-      servicio.nombre.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredServicios(filtered);
-  }, [searchTerm, servicios]);
-
-  function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
-    setSearchTerm(e.target.value);
-  }
-
-  function openModal(servicio?: Servicio) {
-    if (servicio) {
-      setEditingServicio(servicio);
-      setFormData({
-        nombre: servicio.nombre,
-        descripcion: servicio.descripcion || '',
-        precio: servicio.precio.toString(),
-        duracion_min: servicio.duracion_min.toString(),
-        puntos_otorgados: servicio.puntos_otorgados.toString(),
-        puntos_requeridos: servicio.puntos_requeridos?.toString() || ''
+  const {
+    items: servicios,
+    loading,
+    searchTerm,
+    modalOpen,
+    submitting,
+    modalError,
+    editingItem: editingServicio,
+    formData,
+    handleSearch,
+    openModal,
+    closeModal,
+    handleSubmit,
+    handleDelete,
+    handleChange,
+  } = useAdminList<Servicio, ServicioFormData>({
+    fetchFn: useCallback(() => serviciosService.getAll(), []),
+    filterFn: useCallback(
+      (items: Servicio[], search: string) =>
+        items.filter(s => s.nombre.toLowerCase().includes(search.toLowerCase())),
+      []
+    ),
+    createFn: useCallback(async (data: ServicioFormData) => {
+      await serviciosService.create({
+        nombre: data.nombre.trim(),
+        descripcion: data.descripcion.trim() || null,
+        precio: Math.max(0, Math.round(Number(data.precio))),
+        duracion_min: Math.max(1, Math.round(Number(data.duracion_min))),
+        puntos_otorgados: Math.max(0, Math.round(Number(data.puntos_otorgados))),
+        puntos_requeridos:
+          data.puntos_requeridos && data.puntos_requeridos.trim()
+            ? Math.max(0, Math.round(Number(data.puntos_requeridos)))
+            : null,
+      } as Omit<Servicio, 'id' | 'created_at'>);
+    }, []),
+    updateFn: useCallback(async (id: string, data: ServicioFormData) => {
+      await serviciosService.update(id, {
+        nombre: data.nombre.trim(),
+        descripcion: data.descripcion.trim() || null,
+        precio: Math.max(0, Math.round(Number(data.precio))),
+        duracion_min: Math.max(1, Math.round(Number(data.duracion_min))),
+        puntos_otorgados: Math.max(0, Math.round(Number(data.puntos_otorgados))),
+        puntos_requeridos:
+          data.puntos_requeridos && data.puntos_requeridos.trim()
+            ? Math.max(0, Math.round(Number(data.puntos_requeridos)))
+            : null,
       });
-    } else {
-      setEditingServicio(null);
-      setFormData({
-        nombre: '',
-        descripcion: '',
-        precio: '',
-        duracion_min: '',
-        puntos_otorgados: '',
-        puntos_requeridos: ''
-      });
-    }
-    setModalOpen(true);
-  }
-
-  function closeModal() {
-    setModalOpen(false);
-    setSubmitting(false);
-    setModalError(null);
-    setEditingServicio(null);
-    setFormData({
-      nombre: '',
-      descripcion: '',
-      precio: '',
-      duracion_min: '',
-      puntos_otorgados: '',
-      puntos_requeridos: ''
-    });
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (submitting) return;
-
-    setSubmitting(true);
-    setModalError(null);
-
-    try {
-      const servicioData = {
-        nombre: formData.nombre.trim(),
-        descripcion: formData.descripcion.trim() || null,
-        precio: Math.max(0, Math.round(Number(formData.precio))),
-        duracion_min: Math.max(1, Math.round(Number(formData.duracion_min))),
-        puntos_otorgados: Math.max(0, Math.round(Number(formData.puntos_otorgados))),
-        puntos_requeridos: formData.puntos_requeridos && formData.puntos_requeridos.trim() 
-          ? Math.max(0, Math.round(Number(formData.puntos_requeridos))) 
-          : null
-      };
-
-      if (editingServicio) {
-        await serviciosService.update(editingServicio.id, servicioData);
-      } else {
-        await serviciosService.create(servicioData);
-      }
-
-      const data = await serviciosService.getAll();
-      setServicios(data);
-      setFilteredServicios(data);
-      closeModal();
-    } catch (error: any) {
-      console.error('Error al guardar servicio:', error);
-      const message = error.message || 'No se pudo guardar el servicio.';
-      setModalError(`Error: ${message}`);
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  async function handleDelete(id: string) {
-    if (!confirm('¿Estás segura de que deseas eliminar este servicio?')) return;
-
-    try {
+    }, []),
+    deleteFn: useCallback(async (id: string) => {
       await serviciosService.delete(id);
-      const data = await serviciosService.getAll();
-      setServicios(data);
-      setFilteredServicios(data);
-    } catch (error) {
-      console.error('Error al eliminar servicio:', error);
-    }
-  }
-
-  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    const { id, name, value } = e.target;
-    setFormData({
-      ...formData,
-      [id || name]: value
-    });
-  }
+    }, []),
+    initialFormData: INITIAL_FORM,
+    mapItemToForm: useCallback(
+      (s: Servicio): ServicioFormData => ({
+        nombre: s.nombre,
+        descripcion: s.descripcion || '',
+        precio: s.precio.toString(),
+        duracion_min: s.duracion_min.toString(),
+        puntos_otorgados: s.puntos_otorgados.toString(),
+        puntos_requeridos: s.puntos_requeridos?.toString() || '',
+      }),
+      []
+    ),
+    itemName: 'servicio',
+  });
 
   if (loading) {
     return (
@@ -195,11 +138,11 @@ export default function AdminServicios() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Gem size={24} className="text-primary" />
-              Servicios ({filteredServicios.length})
+              Servicios ({servicios.length})
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {filteredServicios.length === 0 ? (
+            {servicios.length === 0 ? (
               <div className="text-center py-12">
                 <Gem size={48} className="mx-auto text-gray-400 mb-4" />
                 <p className="text-gray-500">
@@ -208,7 +151,7 @@ export default function AdminServicios() {
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {filteredServicios.map((servicio) => (
+                {servicios.map((servicio) => (
                   <div
                     key={servicio.id}
                     className="bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition-shadow"
@@ -277,9 +220,9 @@ export default function AdminServicios() {
                     {editingServicio ? 'Editar Servicio' : 'Nuevo Servicio'}
                   </span>
                 </CardTitle>
-                <button 
+                <button
                   type="button"
-                  onClick={closeModal} 
+                  onClick={closeModal}
                   className="text-gray-400 hover:text-gray-600 transition-colors"
                   aria-label="Cerrar"
                 >
@@ -287,7 +230,7 @@ export default function AdminServicios() {
                 </button>
               </CardHeader>
               <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
+                <form onSubmit={(e) => handleSubmit(e, (d) => d)} className="space-y-4">
                   {modalError && (
                     <div id="modal-error" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
                       {modalError}
@@ -357,16 +300,15 @@ export default function AdminServicios() {
                     name="puntos_requeridos"
                   />
 
-
-                    <div className="flex justify-end gap-3 pt-4">
-                      <Button type="button" variant="outline" onClick={closeModal} disabled={submitting}>
-                        Cancelar
-                      </Button>
-                      <Button type="submit" data-testid="btn-crear-servicio" loading={submitting}>
-                        {editingServicio ? 'Actualizar' : 'Crear'}
-                      </Button>
-                    </div>
-                  </form>
+                  <div className="flex justify-end gap-3 pt-4">
+                    <Button type="button" variant="outline" onClick={closeModal} disabled={submitting}>
+                      Cancelar
+                    </Button>
+                    <Button type="submit" data-testid="btn-crear-servicio" loading={submitting}>
+                      {editingServicio ? 'Actualizar' : 'Crear'}
+                    </Button>
+                  </div>
+                </form>
               </CardContent>
             </Card>
           </div>


### PR DESCRIPTION
## Summary
- Create generic `useAdminList<T, TForm>` hook encapsulating: state management, CRUD handlers, search/filter, modal logic
- Refactor `Servicios.tsx`: 377 → 319 lines (-15%)
- Refactor `Premios.tsx`: 312 → 269 lines (-14%)
- `Clientas.tsx` NOT refactored — fundamentally different pattern (detail view with citas history, no create/delete)

~200 lines of shared boilerplate now centralized in one reusable hook.

Closes #34