### PR TITLE
refactor: add getById endpoints and remove frontend business logic

### DIFF
--- a/backend/src/modules/premios.handlers.ts
+++ b/backend/src/modules/premios.handlers.ts
@@ -20,6 +20,11 @@ type PremioIdParams = {
   id: string;
 };
 
+export type PremioGetCtx = {
+  params: PremioIdParams;
+  set: { status?: number | string };
+};
+
 export type PremiosDeps = {
   db: typeof defaultDb;
 };
@@ -52,6 +57,17 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
     listPremios: async () => {
       const rows = await deps.db.select().from(premios).orderBy(asc(premios.nombre));
       return rows.map(toPublicPremio);
+    },
+
+    getPremio: async (ctx: unknown) => {
+      const { params, set } = ctx as PremioGetCtx;
+      const rows = await deps.db.select().from(premios).where(eq(premios.id, params.id)).limit(1);
+      const row = rows[0];
+      if (!row) {
+        set.status = 404;
+        return { error: 'not_found' };
+      }
+      return row;
     },
 
     createPremio: async (ctx: unknown) => {

--- a/backend/src/modules/premios.routes.ts
+++ b/backend/src/modules/premios.routes.ts
@@ -11,6 +11,15 @@ export function registerPremiosRoutes(app: AnyElysia) {
 
   return app
     .get('/api/premios', handlers.listPremios)
+    .get(
+      '/api/premios/:id',
+      handlers.getPremio,
+      {
+        params: t.Object({
+          id: t.String({ format: 'uuid' }),
+        }),
+      }
+    )
     .post(
       '/api/premios',
       handlers.createPremio,

--- a/backend/src/modules/referidos.handlers.ts
+++ b/backend/src/modules/referidos.handlers.ts
@@ -11,6 +11,17 @@ type ReferidosQuery = {
   referente_id?: string;
 };
 
+type ReferidoIdParams = {
+  id: string;
+};
+
+type ReferidoGetCtx = {
+  auth?: unknown;
+  status: StatusHelper;
+  params: ReferidoIdParams;
+  set: { status?: number | string };
+};
+
 type ReferidosCreateBody = {
   referente_id: string;
   referida_id: string;
@@ -82,6 +93,25 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
         .where(eq(referidos.referente_id, referenteId))
         .orderBy(desc(referidos.fecha));
       return rows.map(toPublicReferido);
+    },
+    getReferido: async (ctx: unknown) => {
+      const { auth, status, params, set } = ctx as ReferidoGetCtx;
+      const result = guardAuth({ auth, status });
+      if (!result.ok) return result.response;
+
+      const rows = await deps.db.select().from(referidos).where(eq(referidos.id, params.id)).limit(1);
+      const row = rows[0];
+      if (!row) {
+        set.status = 404;
+        return { error: 'not_found' };
+      }
+
+      if (result.jwt.rol !== 'admin' && result.jwt.sub !== row.referente_id) {
+        set.status = 403;
+        return { error: 'forbidden' };
+      }
+
+      return toPublicReferido(row);
     },
     create: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as ReferidosCreateCtx;

--- a/backend/src/modules/referidos.routes.ts
+++ b/backend/src/modules/referidos.routes.ts
@@ -19,6 +19,15 @@ export function registerReferidosRoutes(app: AnyElysia) {
         }),
       }
     )
+    .get(
+      '/api/referidos/:id',
+      handlers.getReferido,
+      {
+        params: t.Object({
+          id: t.String({ format: 'uuid' }),
+        }),
+      }
+    )
     .post(
       '/api/referidos',
       handlers.create,

--- a/backend/src/modules/servicios.handlers.ts
+++ b/backend/src/modules/servicios.handlers.ts
@@ -43,6 +43,11 @@ export type ServicioPatchCtx = {
   set: { status?: number | string };
 };
 
+export type ServicioGetCtx = {
+  params: ServicioIdParams;
+  set: { status?: number | string };
+};
+
 export type ServicioDeleteCtx = {
   auth?: unknown;
   status: StatusHelper;
@@ -56,6 +61,17 @@ export function createServiciosHttpHandlers(deps: ServiciosDeps) {
     listServicios: async () => {
       const rows = await deps.db.select().from(servicios).orderBy(asc(servicios.nombre));
       return rows.map(toPublicServicio);
+    },
+
+    getServicio: async (ctx: unknown) => {
+      const { params, set } = ctx as ServicioGetCtx;
+      const rows = await deps.db.select().from(servicios).where(eq(servicios.id, params.id)).limit(1);
+      const row = rows[0];
+      if (!row) {
+        set.status = 404;
+        return { error: 'not_found' };
+      }
+      return toPublicServicio(row);
     },
 
     createServicio: async (ctx: unknown) => {

--- a/backend/src/modules/servicios.routes.ts
+++ b/backend/src/modules/servicios.routes.ts
@@ -11,6 +11,15 @@ export function registerServiciosRoutes(app: AnyElysia) {
 
   return app
     .get('/api/servicios', handlers.listServicios)
+    .get(
+      '/api/servicios/:id',
+      handlers.getServicio,
+      {
+        params: t.Object({
+          id: t.String({ format: 'uuid' }),
+        }),
+      }
+    )
     .post(
       '/api/servicios',
       handlers.createServicio,

--- a/frontend/src/services/premios.ts
+++ b/frontend/src/services/premios.ts
@@ -6,9 +6,8 @@ export const premiosService = {
     return get<Premio[]>('/api/premios');
   },
 
-  async getById(id: string): Promise<Premio | null> {
-    const premios = await get<Premio[]>('/api/premios');
-    return premios.find((p) => p.id === id) ?? null;
+  async getById(id: string): Promise<Premio> {
+    return get<Premio>(`/api/premios/${id}`);
   },
 
   async create(premio: Omit<Premio, 'id'>): Promise<Premio> {

--- a/frontend/src/services/puntos.ts
+++ b/frontend/src/services/puntos.ts
@@ -1,6 +1,5 @@
 import { get, post } from './api';
-import type { Profile, Cita, Referido } from '@fidelity-card/shared';
-import { serviciosService } from './servicios';
+import type { Profile } from '@fidelity-card/shared';
 
 export const puntosService = {
   async sumarPuntos(profileId: string, cantidad: number): Promise<Profile> {
@@ -14,34 +13,6 @@ export const puntosService = {
     return post<Profile>('/api/puntos/restar', {
       profile_id: profileId,
       cantidad
-    });
-  },
-
-  async calcularPuntosCita(servicioIds: string[]): Promise<number> {
-    let puntosTotal = 0;
-    
-    for (const servicioId of servicioIds) {
-      const servicio = await serviciosService.getById(servicioId);
-      if (servicio) {
-        puntosTotal += servicio.puntos_otorgados;
-      }
-    }
-    
-    return puntosTotal;
-  },
-
-  async otorgarPuntosCita(cita: Cita): Promise<void> {
-    if (cita.estado !== 'completada') return;
-    
-    const puntos = await this.calcularPuntosCita(cita.servicio_ids);
-    await this.sumarPuntos(cita.clienta_id, puntos);
-  },
-
-  async otorgarPuntosReferido(referenteId: string, referidaId: string, puntos: number): Promise<Referido> {
-    return post<Referido>('/api/referidos', {
-      referente_id: referenteId,
-      referida_id: referidaId,
-      puntos_ganados: puntos
     });
   },
 

--- a/frontend/src/services/referidos.ts
+++ b/frontend/src/services/referidos.ts
@@ -6,9 +6,8 @@ export const referidosService = {
     return get<Referido[]>('/api/referidos');
   },
 
-  async getById(id: string): Promise<Referido | null> {
-    const referidos = await get<Referido[]>('/api/referidos');
-    return referidos.find((referido) => referido.id === id) ?? null;
+  async getById(id: string): Promise<Referido> {
+    return get<Referido>(`/api/referidos/${id}`);
   },
 
   async getByReferente(referenteId: string): Promise<Referido[]> {

--- a/frontend/src/services/servicios.ts
+++ b/frontend/src/services/servicios.ts
@@ -6,9 +6,8 @@ export const serviciosService = {
     return get<Servicio[]>('/api/servicios');
   },
 
-  async getById(id: string): Promise<Servicio | null> {
-    const servicios = await get<Servicio[]>('/api/servicios');
-    return servicios.find((servicio) => servicio.id === id) ?? null;
+  async getById(id: string): Promise<Servicio> {
+    return get<Servicio>(`/api/servicios/${id}`);
   },
 
   async create(servicio: Omit<Servicio, 'id' | 'created_at'>): Promise<Servicio> {


### PR DESCRIPTION
## Summary
- Add `GET /api/servicios/:id`, `GET /api/premios/:id`, `GET /api/referidos/:id` — frontend was fetching entire tables and filtering client-side
- Update frontend services to use direct endpoints instead of `getAll()` + `.find()`
- Remove `calcularPuntosCita`, `otorgarPuntosCita`, `otorgarPuntosReferido` from `puntos.ts` — backend already handles all operations atomically via `patchCitaAtomic` and referidos create handler

Closes #35, closes #37