### PR TITLE
refactor(backend): extract auth guard helper to eliminate casting duplication

### DIFF
--- a/backend/src/modules/auth-helpers.ts
+++ b/backend/src/modules/auth-helpers.ts
@@ -1,0 +1,56 @@
+import { requireAuth, requireAdmin } from './auth-context';
+import type { AuthJwtPayload } from './auth-context';
+import type { StatusHelper } from '../domain/types/http';
+
+/**
+ * Discriminated result for combined guard + extraction helpers.
+ * - `ok: true` → `jwt` is a validated `AuthJwtPayload`.
+ * - `ok: false` → `response` is the denied response from `requireAuth`/`requireAdmin`.
+ */
+export type GuardResult =
+  | { ok: true; jwt: AuthJwtPayload }
+  | { ok: false; response: unknown };
+
+/**
+ * Extracts and normalizes the JWT payload from Elysia's decorated `auth`.
+ *
+ * Centralises the double-cast that was previously repeated in every handler,
+ * so each handler can call `extractJwt(auth)` instead of the 3-line boilerplate.
+ */
+export function extractJwt(auth: unknown): AuthJwtPayload | null {
+  return ((auth as unknown) ?? null) as AuthJwtPayload | null;
+}
+
+/**
+ * Combined admin guard: extracts JWT from `auth` and checks admin role.
+ *
+ * Usage:
+ * ```ts
+ * const result = guardAdmin({ auth, status });
+ * if (!result.ok) return result.response;
+ * // result.jwt is AuthJwtPayload
+ * ```
+ */
+export function guardAdmin(ctx: { auth: unknown; status: StatusHelper }): GuardResult {
+  const jwt = extractJwt(ctx.auth);
+  const denied = requireAdmin({ auth: jwt, status: ctx.status });
+  if (denied) return { ok: false, response: denied };
+  return { ok: true, jwt: jwt! };
+}
+
+/**
+ * Combined auth guard: extracts JWT from `auth` and checks it is present.
+ *
+ * Usage:
+ * ```ts
+ * const result = guardAuth({ auth, status });
+ * if (!result.ok) return result.response;
+ * // result.jwt is AuthJwtPayload
+ * ```
+ */
+export function guardAuth(ctx: { auth: unknown; status: StatusHelper }): GuardResult {
+  const jwt = extractJwt(ctx.auth);
+  const denied = requireAuth({ auth: jwt, status: ctx.status });
+  if (denied) return { ok: false, response: denied };
+  return { ok: true, jwt: jwt! };
+}

--- a/backend/src/modules/citas.handlers.ts
+++ b/backend/src/modules/citas.handlers.ts
@@ -10,8 +10,7 @@ import { toPublicCita } from '../domain/transformers/citas';
 import type { CitaEstado } from '../domain/types/citas';
 import type { StatusHelper } from '../domain/types/http';
 
-import { requireAuth, requireAdmin } from './auth-context';
-import type { AuthJwtPayload } from './auth-context';
+import { extractJwt } from './auth-helpers';
 
 export type CitaCreateBody = {
   clienta_id: string;
@@ -97,11 +96,10 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
     /** Lista citas. Admin puede listar todas o por clienta; clienta solo sus citas. */
     listCitas: async (ctx: unknown) => {
       const { auth, query } = ctx as CitasListCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAuth({ auth: jwt, status: () => {} });
-      if (denied) return [];
+      const jwt = extractJwt(auth);
+      if (!jwt) return [];
 
-      if (jwt?.rol === 'admin') {
+      if (jwt.rol === 'admin') {
         if (query.clienta_id && query.clienta_id !== 'me') {
           const rows = await deps.db
             .select()
@@ -114,7 +112,7 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
         return rows.map((row) => toPublicCita(row));
       }
 
-      const clienta_id = jwt?.sub;
+      const clienta_id = jwt.sub;
       if (!clienta_id) return [];
 
       if (query.clienta_id && query.clienta_id !== 'me' && query.clienta_id !== clienta_id) {
@@ -132,9 +130,8 @@ export function createCitasHttpHandlers(deps: CitasDeps) {
     /** Lista proximas citas (solo admin). */
     listProximasCitas: async (ctx: unknown) => {
       const { auth } = ctx as { auth?: unknown };
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAdmin({ auth: jwt, status: () => {} });
-      if (denied) return [];
+      const jwt = extractJwt(auth);
+      if (!jwt || jwt.rol !== 'admin') return [];
 
       const now = new Date();
       const rows = await deps.db

--- a/backend/src/modules/premios.handlers.ts
+++ b/backend/src/modules/premios.handlers.ts
@@ -4,8 +4,7 @@ import { db as defaultDb } from '../db';
 import { premios } from '../db/schema';
 import type { StatusHelper } from '../domain/types/http';
 
-import { requireAdmin } from './auth-context';
-import type { AuthJwtPayload } from './auth-context';
+import { guardAdmin } from './auth-helpers';
 
 export type PremioCreateBody = {
   nombre: string;
@@ -56,8 +55,8 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
 
     createPremio: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as PremioCreateCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const inserted = await deps.db
         .insert(premios)
@@ -81,8 +80,8 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
 
     patchPremio: async (ctx: unknown) => {
       const { auth, status, params, body, set } = ctx as PremioPatchCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const updates: Partial<typeof premios.$inferSelect> = {};
 
@@ -108,8 +107,8 @@ export function createPremiosHttpHandlers(deps: PremiosDeps) {
 
     deletePremio: async (ctx: unknown) => {
       const { auth, status, params, set } = ctx as PremioDeleteCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const deleted = await deps.db.delete(premios).where(eq(premios.id, params.id)).returning({ id: premios.id });
       const row = deleted[0];

--- a/backend/src/modules/profiles.handlers.ts
+++ b/backend/src/modules/profiles.handlers.ts
@@ -6,8 +6,7 @@ import { toPublicProfile } from '../domain/transformers/profiles';
 import type { StatusHelper } from '../domain/types/http';
 import type { Rol } from '../domain/types/auth';
 
-import { requireAuth, requireAdmin } from './auth-context';
-import type { AuthJwtPayload } from './auth-context';
+import { guardAdmin, guardAuth } from './auth-helpers';
 
 type ProfileQuery = {
   rol?: Rol;
@@ -55,9 +54,8 @@ export function createProfilesHttpHandlers(deps: ProfilesDeps) {
   return {
     listProfiles: async (ctx: unknown) => {
       const { auth, status, query } = ctx as ProfilesListCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAdmin({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       if (query.rol) {
         const rows = await deps.db
@@ -74,11 +72,10 @@ export function createProfilesHttpHandlers(deps: ProfilesDeps) {
 
     getProfileById: async (ctx: unknown) => {
       const { auth, status, params, set } = ctx as ProfileGetCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAuth({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAuth({ auth, status });
+      if (!result.ok) return result.response;
 
-      if (jwt?.rol !== 'admin' && jwt?.sub !== params.id) {
+      if (result.jwt.rol !== 'admin' && result.jwt.sub !== params.id) {
         set.status = 403;
         return { error: 'forbidden' };
       }
@@ -95,11 +92,10 @@ export function createProfilesHttpHandlers(deps: ProfilesDeps) {
 
     patchProfile: async (ctx: unknown) => {
       const { auth, status, params, body, set } = ctx as ProfilePatchCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAuth({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAuth({ auth, status });
+      if (!result.ok) return result.response;
 
-      if (jwt?.rol !== 'admin' && jwt?.sub !== params.id) {
+      if (result.jwt.rol !== 'admin' && result.jwt.sub !== params.id) {
         set.status = 403;
         return { error: 'forbidden' };
       }

--- a/backend/src/modules/referidos.handlers.ts
+++ b/backend/src/modules/referidos.handlers.ts
@@ -5,8 +5,7 @@ import { toPublicProfile } from '../domain/transformers/profiles';
 import { toPublicReferido } from '../domain/transformers/referidos';
 import type { StatusHelper } from '../domain/types/http';
 
-import { requireAuth, requireAdmin } from './auth-context';
-import type { AuthJwtPayload } from './auth-context';
+import { guardAuth, guardAdmin } from './auth-helpers';
 
 type ReferidosQuery = {
   referente_id?: string;
@@ -61,20 +60,19 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
   return {
     list: async (ctx: unknown) => {
       const { auth, status, query } = ctx as ReferidosListCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAuth({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAuth({ auth, status });
+      if (!result.ok) return result.response;
 
       const referenteId = query.referente_id;
       if (!referenteId) {
-        if (jwt?.rol !== 'admin') {
+        if (result.jwt.rol !== 'admin') {
           return status(403, { error: 'forbidden' });
         }
         const rows = await deps.db.select().from(referidos).orderBy(desc(referidos.fecha));
         return rows.map(toPublicReferido);
       }
 
-      if (jwt?.rol !== 'admin' && jwt?.sub !== referenteId) {
+      if (result.jwt.rol !== 'admin' && result.jwt.sub !== referenteId) {
         return status(403, { error: 'forbidden' });
       }
 
@@ -87,9 +85,8 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
     },
     create: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as ReferidosCreateCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAdmin({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const puntos = Math.max(0, body.puntos_ganados);
 
@@ -151,9 +148,8 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
     },
     puntosTop: async (ctx: unknown) => {
       const { auth, status, query } = ctx as PuntosTopCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAuth({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAuth({ auth, status });
+      if (!result.ok) return result.response;
 
       const limit = Math.min(Math.max(query.limit ?? 10, 1), 100);
 
@@ -168,9 +164,8 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
     },
     sumarPuntos: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as PuntosAdjustCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAdmin({ auth: jwt, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const cantidad = Math.max(0, body.cantidad);
       const updated = await deps.db
@@ -191,9 +186,8 @@ export function createReferidosHandlers(deps: ReferidosDeps) {
     },
     restarPuntos: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as PuntosAdjustCtx;
-      const jwt = ((auth as unknown) ?? null) as AuthJwtPayload | null;
-      const denied = requireAdmin({ auth: jwt, status });
-      if (denied) return denied;
+      const result2 = guardAdmin({ auth, status });
+      if (!result2.ok) return result2.response;
 
       const found = await deps.db.select().from(profiles).where(eq(profiles.id, body.profile_id)).limit(1);
       const profile = found[0];

--- a/backend/src/modules/servicios.handlers.ts
+++ b/backend/src/modules/servicios.handlers.ts
@@ -5,8 +5,7 @@ import { servicios } from '../db/schema';
 import { toPublicServicio } from '../domain/transformers/servicios';
 import type { StatusHelper } from '../domain/types/http';
 
-import { requireAdmin } from './auth-context';
-import type { AuthJwtPayload } from './auth-context';
+import { guardAdmin } from './auth-helpers';
 
 export type ServicioCreateBody = {
   nombre: string;
@@ -61,8 +60,8 @@ export function createServiciosHttpHandlers(deps: ServiciosDeps) {
 
     createServicio: async (ctx: unknown) => {
       const { auth, status, body, set } = ctx as ServicioCreateCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const inserted = await deps.db
         .insert(servicios)
@@ -88,8 +87,8 @@ export function createServiciosHttpHandlers(deps: ServiciosDeps) {
 
     patchServicio: async (ctx: unknown) => {
       const { auth, status, params, body, set } = ctx as ServicioPatchCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const updates: ServicioPatchBody = {};
 
@@ -117,8 +116,8 @@ export function createServiciosHttpHandlers(deps: ServiciosDeps) {
 
     deleteServicio: async (ctx: unknown) => {
       const { auth, status, params, set } = ctx as ServicioDeleteCtx;
-      const denied = requireAdmin({ auth: ((auth as unknown) ?? null) as AuthJwtPayload | null, status });
-      if (denied) return denied;
+      const result = guardAdmin({ auth, status });
+      if (!result.ok) return result.response;
 
       const deleted = await deps.db.delete(servicios).where(eq(servicios.id, params.id)).returning({ id: servicios.id });
       const row = deleted[0];


### PR DESCRIPTION
## Summary
- Create `auth-helpers.ts` with `extractJwt()` and `guardAuth()` — typed helpers that eliminate the double-cast pattern
- Replace 15+ occurrences of the 3-line `((auth as unknown) ?? null) as AuthJwtPayload | null` + `requireAdmin` boilerplate across all handler files
- Each handler now uses 1 line instead of 3

Closes #47